### PR TITLE
Open the arrived email when clicking a Windows notification

### DIFF
--- a/src-tauri/src/notify.rs
+++ b/src-tauri/src/notify.rs
@@ -1,10 +1,12 @@
 //! New-mail desktop notifications (Windows toasts) with a mark-read quick
-//! action. Sent from the sync engine when new inbox mail arrives while the
+//! action; a body click focuses the window and opens the newest message's
+//! thread. Sent from the sync engine when new inbox mail arrives while the
 //! window is unfocused; the "notifications" setting turns them off.
 
 use crate::db::{queries, Db};
 use crate::state::AppState;
-use tauri::{AppHandle, Manager};
+use serde_json::json;
+use tauri::{AppHandle, Emitter, Manager};
 use tauri_winrt_notification::Toast;
 
 const AUMID: &str = "com.skim.app";
@@ -103,9 +105,16 @@ pub async fn notify_new_mail(app: &AppHandle, db: &Db, message_pks: &[i64]) {
         }
     }
 
-    // Newest of the batch shapes the toast.
+    // Newest of the batch shapes the toast (and is what a body click opens).
     let pks = message_pks.to_vec();
-    let newest: Option<(Option<String>, Option<String>, Option<String>)> = db
+    type NewestRow = (
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        i64,
+        Option<i64>,
+    );
+    let newest: Option<NewestRow> = db
         .call(move |conn| {
             use rusqlite::OptionalExtension;
             let placeholders = pks.iter().map(|_| "?").collect::<Vec<_>>().join(",");
@@ -113,20 +122,21 @@ pub async fn notify_new_mail(app: &AppHandle, db: &Db, message_pks: &[i64]) {
                 pks.iter().map(|p| p as &dyn rusqlite::ToSql).collect();
             conn.query_row(
                 &format!(
-                    "SELECT from_name, from_addr, subject FROM messages
+                    "SELECT from_name, from_addr, subject, folder_id, thread_id FROM messages
                      WHERE id IN ({placeholders}) ORDER BY date DESC LIMIT 1"
                 ),
                 params.as_slice(),
-                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
             )
             .optional()
         })
         .await
         .ok()
         .flatten();
-    let Some((from_name, from_addr, subject)) = newest else {
+    let Some((from_name, from_addr, subject, folder_id, thread_id)) = newest else {
         return;
     };
+    let open_target = thread_id.map(|tid| (folder_id, tid));
 
     let title = from_name
         .filter(|s| !s.is_empty())
@@ -171,10 +181,16 @@ pub async fn notify_new_mail(app: &AppHandle, db: &Db, message_pks: &[i64]) {
                         });
                     }
                     _ => {
-                        // Body click → bring the app forward.
+                        // Body click → bring the app forward on the arrived mail.
                         if let Some(window) = app_for_cb.get_webview_window("main") {
                             let _ = window.unminimize();
                             let _ = window.set_focus();
+                        }
+                        if let Some((folder_id, thread_id)) = open_target {
+                            let _ = app_for_cb.emit(
+                                "mail:open-thread",
+                                json!({ "folderId": folder_id, "threadId": thread_id }),
+                            );
                         }
                     }
                 }

--- a/src/lib/stores/mail.svelte.ts
+++ b/src/lib/stores/mail.svelte.ts
@@ -32,6 +32,13 @@ async function attachListeners() {
     }
     void refreshFolders();
   });
+  // Toast body click: jump to the message's thread.
+  await listen<{ folderId: number; threadId: number }>("mail:open-thread", async (e) => {
+    if (e.payload.folderId !== state.selectedFolderId) {
+      await selectFolder(e.payload.folderId);
+    }
+    state.selectedThreadId = e.payload.threadId;
+  });
   await listen<{ state: SyncState; message: string | null }>("sync:status", (e) => {
     state.syncState = e.payload.state;
     state.syncMessage = e.payload.message ?? null;


### PR DESCRIPTION
## What

Clicking the body of a new-mail toast now opens the email that arrived, instead of just focusing the window.

## How

- **src-tauri/src/notify.rs**: the newest-message query additionally fetches `folder_id` and `thread_id`. On toast body activation the existing focus/unminimize behavior is kept, plus a `mail:open-thread` event is emitted with those ids. The "Mark read" button path is unchanged.
- **src/lib/stores/mail.svelte.ts**: the store listens for `mail:open-thread`, switches to the message's folder if it isn't selected, and sets `selectedThreadId` — the reading pane then loads and opens the thread (marking it read as usual).

When a batch of messages arrives, the newest one is opened — the same message whose sender/subject the toast shows. If `thread_id` is somehow NULL, the click falls back to just focusing the window.

## Testing

- `cargo check` and `svelte-check` pass.
- Release build installed locally; toast callbacks require a live manual click, so the final click-through was left for manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
