### PR TITLE
feat: thread context and follow-up dialog for Ask-about-this

### DIFF
--- a/src-tauri/src/ai/prompts.rs
+++ b/src-tauri/src/ai/prompts.rs
@@ -244,18 +244,37 @@ pub fn adjust(
     (system, user)
 }
 
-pub fn ask(email: &EmailBlock, question: &str, now: &str, locale: &str) -> (String, String) {
+/// Q&A session over an email conversation. `chain` is chronological; the last
+/// entry is the message open in the reading pane. Returns (system, preamble) —
+/// the preamble is folded into the first user turn, questions arrive as turns.
+pub fn ask_session(chain: &[EmailBlock], now: &str, locale: &str) -> (String, String) {
+    if chain.len() <= 1 {
+        let system = format!(
+            "You answer the user's questions about a specific email. Answer only from \
+             the email's content; if it doesn't contain the answer, say so plainly. \
+             Be brief. {} {}",
+            now_block(now),
+            locale_line(locale)
+        );
+        let preamble = render_emails(chain, MAX_BODY_CHARS);
+        return (system, preamble);
+    }
     let system = format!(
-        "You answer questions about a specific email. Answer only from the email's \
-         content; if it doesn't contain the answer, say so plainly. Be brief. {} {}",
+        "You answer the user's questions about an email conversation. Answer only \
+         from the emails' content; if they don't contain the answer, say so plainly. \
+         Questions are usually about the LAST (most recent) message — use the earlier \
+         messages as context. Be brief. {} {}",
         now_block(now),
         locale_line(locale)
     );
-    let user = format!(
-        "{}\n\nQuestion: {question}",
-        render_emails(std::slice::from_ref(email), MAX_BODY_CHARS)
+    let (earlier, last) = chain.split_at(chain.len() - 1);
+    let per_email = (MAX_BODY_CHARS / chain.len()).min(MAX_CHAIN_CHARS);
+    let preamble = format!(
+        "The email conversation, oldest first:\n\n{}\n\n{}",
+        render_emails(earlier, per_email),
+        render_emails(last, MAX_BODY_CHARS)
     );
-    (system, user)
+    (system, preamble)
 }
 
 pub fn chat(

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -349,8 +349,8 @@ async fn writer_profile(state: &State<'_, AppState>) -> Result<prompts::WriterPr
         .await
 }
 
-/// The reply-to message plus up to `limit - 1` earlier messages of its
-/// thread, in chronological order (the replied-to message is last).
+/// The anchor message plus up to `limit - 1` earlier messages of its
+/// thread, in chronological order (the anchor message is last).
 async fn reply_chain(
     state: &State<'_, AppState>,
     message_id: i64,
@@ -367,7 +367,7 @@ async fn reply_chain(
             let Some(thread_id) = thread_id else {
                 return Ok(vec![message_id]);
             };
-            // Earlier part of the thread, ending at the replied-to message.
+            // Earlier part of the thread, ending at the anchor message.
             let mut stmt = conn.prepare_cached(
                 "SELECT id FROM messages
                  WHERE thread_id = ?1 AND (date < ?2 OR id = ?3)
@@ -456,40 +456,21 @@ pub async fn ai_adjust_draft(
     Ok(())
 }
 
-/// One turn of the composer's drafting conversation, as sent by the frontend.
-/// `role` is "user" (an instruction) or "assistant" (a draft the AI produced).
+/// One turn of an AI conversation (composer drafting or ask sessions), as sent
+/// by the frontend. `role` is "user" or "assistant".
 #[derive(Debug, Deserialize)]
-pub struct ComposeTurn {
+pub struct AiTurn {
     pub role: String,
     pub content: String,
 }
 
-/// Interactive email drafting. Unlike `ai_draft`/`ai_adjust_draft` (one-shot),
-/// this carries the whole conversation so the user can refine the draft turn by
-/// turn against a single shared context. The assistant's reply IS the current
-/// email body; the newest turn must be a user instruction.
-#[tauri::command]
-pub async fn ai_compose(
-    state: State<'_, AppState>,
-    request_id: String,
-    turns: Vec<ComposeTurn>,
-    reply_to_message_id: Option<i64>,
-    channel: Channel<AiEvent>,
-) -> Result<()> {
-    let ctx = ai_context(&state.db).await?;
-    // A reply sees the whole conversation, not just the last message.
-    let chain = match reply_to_message_id {
-        Some(id) => reply_chain(&state, id, 8).await?,
-        None => Vec::new(),
-    };
-    let profile = writer_profile(&state).await?;
-    let (system, preamble) = prompts::compose_session(&chain, &profile, &ctx.now, &ctx.locale);
-
-    // The reply/quote context is folded into the first user turn so the whole
-    // session shares it without re-sending it every round.
+/// Turns as sent by the frontend → provider messages, with `preamble` folded
+/// into the first user turn so the whole session shares the context without
+/// re-sending it every round.
+fn session_messages(turns: &[AiTurn], preamble: &str) -> Vec<ChatMessage> {
     let mut messages: Vec<ChatMessage> = Vec::with_capacity(turns.len());
     let mut injected = false;
-    for turn in &turns {
+    for turn in turns {
         let role: &'static str = if turn.role == "assistant" {
             "assistant"
         } else {
@@ -503,6 +484,31 @@ pub async fn ai_compose(
         };
         messages.push(ChatMessage { role, content });
     }
+    messages
+}
+
+/// Interactive email drafting. Unlike `ai_draft`/`ai_adjust_draft` (one-shot),
+/// this carries the whole conversation so the user can refine the draft turn by
+/// turn against a single shared context. The assistant's reply IS the current
+/// email body; the newest turn must be a user instruction.
+#[tauri::command]
+pub async fn ai_compose(
+    state: State<'_, AppState>,
+    request_id: String,
+    turns: Vec<AiTurn>,
+    reply_to_message_id: Option<i64>,
+    channel: Channel<AiEvent>,
+) -> Result<()> {
+    let ctx = ai_context(&state.db).await?;
+    // A reply sees the whole conversation, not just the last message.
+    let chain = match reply_to_message_id {
+        Some(id) => reply_chain(&state, id, 8).await?,
+        None => Vec::new(),
+    };
+    let profile = writer_profile(&state).await?;
+    let (system, preamble) = prompts::compose_session(&chain, &profile, &ctx.now, &ctx.locale);
+
+    let messages = session_messages(&turns, &preamble);
     if messages.is_empty() {
         return Err(SkimError::other("ai", "no instruction provided"));
     }
@@ -519,23 +525,30 @@ pub async fn ai_compose(
     Ok(())
 }
 
+/// Q&A about the open message's conversation. Carries the whole dialog so the
+/// user can ask follow-ups against a single shared context; `message_id` is
+/// the message open in the reading pane, the newest turn is a user question.
 #[tauri::command]
 pub async fn ai_ask(
     state: State<'_, AppState>,
     request_id: String,
     message_id: i64,
-    question: String,
+    turns: Vec<AiTurn>,
     channel: Channel<AiEvent>,
 ) -> Result<()> {
     let ctx = ai_context(&state.db).await?;
-    let email = email_block(&state, message_id).await?;
-    let (system, user) = prompts::ask(&email, &question, &ctx.now, &ctx.locale);
+    let chain = reply_chain(&state, message_id, 25).await?;
+    let (system, preamble) = prompts::ask_session(&chain, &ctx.now, &ctx.locale);
+    let messages = session_messages(&turns, &preamble);
+    if messages.is_empty() {
+        return Err(SkimError::other("ai", "no question provided"));
+    }
     spawn_stream(
         &state,
         request_id,
         ctx,
         system,
-        user_turn(user),
+        messages,
         2048,
         Vec::new(),
         channel,

--- a/src/components/ReadingPane.svelte
+++ b/src/components/ReadingPane.svelte
@@ -18,13 +18,19 @@
   } | null>(null);
   let askOpen = $state(false);
   let askQuestion = $state("");
+  // The ask dialog so far; completed turns only, the streaming answer lives
+  // in aiPanel.text until "done".
+  let askTurns = $state<{ role: "user" | "assistant"; content: string }[]>([]);
   let askInput: HTMLInputElement | undefined = $state();
+  let askThreadEl: HTMLDivElement | undefined = $state();
   let cancelAi: (() => void) | null = null;
 
   function closeAiPanel() {
     cancelAi?.();
     aiPanel = null;
     askOpen = false;
+    askTurns = [];
+    askQuestion = "";
   }
 
   function startAi(kind: AiPanelKind, command: "ai_summarize" | "ai_ask", args: Record<string, unknown>) {
@@ -35,9 +41,20 @@
         if (aiPanel) aiPanel = { ...aiPanel, text: aiPanel.text + text };
       },
       done: () => {
-        if (aiPanel) aiPanel = { ...aiPanel, status: "done" };
+        if (!aiPanel) return;
+        if (aiPanel.kind === "ask") {
+          askTurns.push({ role: "assistant", content: aiPanel.text });
+          aiPanel = null;
+          queueMicrotask(() => askInput?.focus());
+        } else {
+          aiPanel = { ...aiPanel, status: "done" };
+        }
       },
       error: (code, message) => {
+        // Put the failed question back into the input so it can be retried.
+        if (kind === "ask" && askTurns[askTurns.length - 1]?.role === "user") {
+          askQuestion = askTurns.pop()!.content;
+        }
         aiPanel = {
           kind,
           status: "error",
@@ -46,6 +63,13 @@
       },
     });
   }
+
+  // Keep the dialog scrolled to the newest turn / streaming delta.
+  $effect(() => {
+    void aiPanel?.text;
+    void askTurns.length;
+    if (askThreadEl) askThreadEl.scrollTop = askThreadEl.scrollHeight;
+  });
 
   function summarize() {
     if (!detail) return;
@@ -61,8 +85,12 @@
 
   function submitAsk(ev: SubmitEvent) {
     ev.preventDefault();
-    if (!latest || !askQuestion.trim()) return;
-    startAi("ask", "ai_ask", { messageId: latest.id, question: askQuestion.trim() });
+    const question = askQuestion.trim();
+    if (!latest || !question) return;
+    if (aiPanel?.kind === "ask" && aiPanel.status === "streaming") return;
+    askTurns.push({ role: "user", content: question });
+    askQuestion = "";
+    startAi("ask", "ai_ask", { messageId: latest.id, turns: $state.snapshot(askTurns) });
   }
 
   async function aiDraftReply() {
@@ -115,6 +143,8 @@
     cancelAi?.();
     aiPanel = null;
     askOpen = false;
+    askTurns = [];
+    askQuestion = "";
     try {
       const d = await api.getThread(threadId);
       if (mail.selectedThreadId !== threadId) return;
@@ -299,17 +329,40 @@
           <svg width="9" height="9" viewBox="0 0 10 10"><path d="M0 0L10 10M10 0L0 10" stroke="currentColor" stroke-width="1.2" /></svg>
         </button>
         {#if askOpen}
+          {#if askTurns.length > 0 || aiPanel}
+            <div class="ask-thread" bind:this={askThreadEl}>
+              {#each askTurns as turn (turn)}
+                {#if turn.role === "user"}
+                  <div class="ask-q">{turn.content}</div>
+                {:else}
+                  <div class="ai-card">
+                    <div class="ai-label microlabel">{t("ai.answer")}</div>
+                    <div class="ai-text md-body">{@html mdLite(turn.content)}</div>
+                  </div>
+                {/if}
+              {/each}
+              {#if aiPanel}
+                <div class="ai-card" class:error={aiPanel.status === "error"}>
+                  <div class="ai-label microlabel">{t("ai.answer")}</div>
+                  {#if aiPanel.text === "" && aiPanel.status === "streaming"}
+                    <span class="thinking">{t("ai.thinking")}</span>
+                  {:else}
+                    <div class="ai-text md-body">{@html mdLite(aiPanel.text)}</div>
+                  {/if}
+                </div>
+              {/if}
+            </div>
+          {/if}
           <form class="ask-form" onsubmit={submitAsk}>
             <span class="ai-spark">✦</span>
             <input
               bind:this={askInput}
               bind:value={askQuestion}
-              placeholder={t("ai.ask_placeholder")}
+              placeholder={askTurns.length > 0 ? t("ai.ask_followup") : t("ai.ask_placeholder")}
               spellcheck="false"
             />
           </form>
-        {/if}
-        {#if aiPanel}
+        {:else if aiPanel}
           <div class="ai-card" class:error={aiPanel.status === "error"}>
             <div class="ai-label microlabel">
               {aiPanel.kind === "summary" ? t("ai.summary") : t("ai.answer")}
@@ -607,6 +660,30 @@
   .dock-close:hover {
     background: var(--hover);
     color: var(--text);
+  }
+
+  .ask-thread {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-height: 26vh;
+    overflow-y: auto;
+    margin-bottom: 10px;
+  }
+  .ask-thread .ai-card {
+    margin-top: 0;
+  }
+  .ask-q {
+    align-self: flex-end;
+    max-width: 80%;
+    margin-right: 30px;
+    padding: 8px 12px;
+    border: 1px solid var(--hairline-strong);
+    border-radius: var(--radius-m);
+    font-size: 13.5px;
+    color: var(--text-dim);
+    white-space: pre-wrap;
+    user-select: text;
   }
 
   .ask-form {

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -72,6 +72,7 @@
   "ai.summarize": "Zusammenfassen",
   "ai.ask_about": "Dazu fragen",
   "ai.ask_placeholder": "Frage zu dieser E-Mail…",
+  "ai.ask_followup": "Weitere Frage stellen…",
   "ai.thinking": "Denke nach…",
   "ai.sources": "Quellen",
   "ai.recap": "KI-Überblick",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -72,6 +72,7 @@
   "ai.summarize": "Summarize",
   "ai.ask_about": "Ask about this",
   "ai.ask_placeholder": "Ask about this email…",
+  "ai.ask_followup": "Ask a follow-up…",
   "ai.thinking": "Thinking…",
   "ai.sources": "Sources",
   "ai.recap": "AI Recap",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -72,6 +72,7 @@
   "ai.summarize": "Resumir",
   "ai.ask_about": "Preguntar sobre esto",
   "ai.ask_placeholder": "Pregunta sobre este correo…",
+  "ai.ask_followup": "Haz otra pregunta…",
   "ai.thinking": "Pensando…",
   "ai.sources": "Fuentes",
   "ai.recap": "Resumen IA",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -72,6 +72,7 @@
   "ai.summarize": "Résumer",
   "ai.ask_about": "Poser une question",
   "ai.ask_placeholder": "Une question sur cet e-mail…",
+  "ai.ask_followup": "Posez une autre question…",
   "ai.thinking": "Réflexion…",
   "ai.sources": "Sources",
   "ai.recap": "Récap IA",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -72,6 +72,7 @@
   "ai.summarize": "Riassumi",
   "ai.ask_about": "Chiedi su questo",
   "ai.ask_placeholder": "Chiedi qualcosa su questa email…",
+  "ai.ask_followup": "Fai un'altra domanda…",
   "ai.thinking": "Sto pensando…",
   "ai.sources": "Fonti",
   "ai.recap": "Riepilogo IA",

--- a/src/lib/i18n/locales/ja.json
+++ b/src/lib/i18n/locales/ja.json
@@ -70,6 +70,7 @@
   "ai.summarize": "要約",
   "ai.ask_about": "これについて質問",
   "ai.ask_placeholder": "このメールについて質問…",
+  "ai.ask_followup": "続けて質問…",
   "ai.thinking": "考え中…",
   "ai.sources": "出典",
   "ai.recap": "AI まとめ",

--- a/src/lib/i18n/locales/ko.json
+++ b/src/lib/i18n/locales/ko.json
@@ -70,6 +70,7 @@
   "ai.summarize": "요약",
   "ai.ask_about": "질문하기",
   "ai.ask_placeholder": "이 메일에 대해 질문…",
+  "ai.ask_followup": "추가 질문하기…",
   "ai.thinking": "생각 중…",
   "ai.sources": "출처",
   "ai.recap": "AI 요약",

--- a/src/lib/i18n/locales/pl.json
+++ b/src/lib/i18n/locales/pl.json
@@ -76,6 +76,7 @@
   "ai.summarize": "Streść",
   "ai.ask_about": "Zapytaj o to",
   "ai.ask_placeholder": "Zapytaj o ten e-mail…",
+  "ai.ask_followup": "Zadaj kolejne pytanie…",
   "ai.thinking": "Myślę…",
   "ai.sources": "Źródła",
   "ai.recap": "Podsumowanie AI",

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -76,6 +76,7 @@
   "ai.summarize": "Суммаризировать",
   "ai.ask_about": "Спросить об этом",
   "ai.ask_placeholder": "Спросите об этом письме…",
+  "ai.ask_followup": "Задайте следующий вопрос…",
   "ai.thinking": "Думаю…",
   "ai.sources": "Источники",
   "ai.recap": "AI-сводка",

--- a/src/lib/i18n/locales/sr.json
+++ b/src/lib/i18n/locales/sr.json
@@ -74,6 +74,7 @@
   "ai.summarize": "Sažmi",
   "ai.ask_about": "Pitaj o ovome",
   "ai.ask_placeholder": "Pitaj o ovom imejlu…",
+  "ai.ask_followup": "Postavi još jedno pitanje…",
   "ai.thinking": "Razmišljam…",
   "ai.sources": "Izvori",
   "ai.recap": "AI pregled",

--- a/src/lib/i18n/locales/zh.json
+++ b/src/lib/i18n/locales/zh.json
@@ -70,6 +70,7 @@
   "ai.summarize": "总结",
   "ai.ask_about": "就此提问",
   "ai.ask_placeholder": "针对这封邮件提问…",
+  "ai.ask_followup": "继续提问…",
   "ai.thinking": "思考中…",
   "ai.sources": "来源",
   "ai.recap": "AI 摘要",


### PR DESCRIPTION
## What

"Ask about this" (Спросить об этом) now sees the whole email conversation and works as a dialog:

- **Thread context**: `ai_ask` builds its context from the reply chain via the existing `reply_chain` helper — up to 25 messages, chronological. Earlier messages are truncated per the draft-chain budget (`min(MAX_BODY_CHARS / n, MAX_CHAIN_CHARS)`); the message open in the reading pane keeps the full 24k-char budget. Single-message threads keep the previous prompt wording.
- **Follow-up dialog**: the command now carries the full Q&A as `turns` (same pattern as `ai_compose`; the shared fold-in logic is extracted into `session_messages`, and `ComposeTurn` is renamed to `AiTurn`). The ask dock renders the transcript (questions right-aligned, answers as Skim AI cards) with auto-scroll and keeps the input open for follow-ups.
- On error the failed question is returned to the input for retry; switching threads or closing the dock resets the dialog.
- New locale key `ai.ask_followup` in all 11 locales.

## Why

Previously `ai_ask` sent only the single latest message, so questions about earlier context ("what does he mean by 'prompt confirmation'?") got "the email doesn't say" answers, and there was no way to ask a follow-up.

## Notes for review

- Dialog history is not persisted — it lives while the thread is open.
- The chain context is rebuilt and re-sent on every question (same as `ai_compose`); bodies are served from the SQLite cache after the first ask (`email_block` is best-effort IMAP, as in `ai_summarize`).
- Verified with `cargo check` and `svelte-check` (both clean); manual dev-mode testing of the streaming flow still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
