### PR TITLE
feat(palette): expand AI chat to near-fullscreen

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -14,6 +14,7 @@ const ALLOWED: &[&str] = &[
     "group_threads",
     "last_from_account",
     "sidebar_collapsed",
+    "palette_expanded",
     "autostart",
     "ai_model",
     "ai_provider",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -107,6 +107,7 @@
           const normalized = ui.hydrate(settings.theme);
           if (settings.theme !== normalized) void api.setSetting("theme", normalized).catch(() => {});
           if (settings.sidebar_collapsed) ui.setSidebarCollapsed(settings.sidebar_collapsed === "on");
+          if (settings.palette_expanded) ui.setPaletteExpanded(settings.palette_expanded === "on");
         } catch {
           // settings are best-effort at boot
         }
@@ -197,9 +198,12 @@
     // Letter shortcuts match the physical key (e.code), not the produced
     // character (e.key): in a Cyrillic (or any non-Latin) layout the K key
     // emits "л", not "k", so an e.key check would only work in a US layout.
+    // Ctrl/Cmd+K opens the palette (idempotent — no-op when already open). When
+    // it's open and a chat is active, the palette's own window handler repurposes
+    // this chord to toggle the expanded view instead of closing.
     if ((e.ctrlKey || e.metaKey) && e.code === "KeyK") {
       e.preventDefault();
-      palette.toggle();
+      palette.show();
       return;
     }
     if ((e.ctrlKey || e.metaKey) && e.code === "KeyN") {

--- a/src/components/CommandPalette.svelte
+++ b/src/components/CommandPalette.svelte
@@ -294,6 +294,13 @@
       } else {
         palette.hide();
       }
+      return;
+    }
+    // While a chat is open, repurpose Ctrl/Cmd+K to toggle the expanded view
+    // instead of closing the palette (App keeps it open via palette.show()).
+    if (chat && (e.ctrlKey || e.metaKey) && e.code === "KeyK") {
+      e.preventDefault();
+      ui.togglePaletteExpanded();
     }
   }
 
@@ -311,8 +318,26 @@
   <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
   <div class="overlay" onclick={() => palette.hide()}>
     <!-- svelte-ignore a11y_click_events_have_key_events, a11y_no_static_element_interactions -->
-    <div class="panel" onclick={(e) => e.stopPropagation()}>
+    <div class="panel" class:expanded={chat && ui.paletteExpanded} onclick={(e) => e.stopPropagation()}>
       {#if chat}
+        <button
+          class="expand-toggle"
+          onclick={() => ui.togglePaletteExpanded()}
+          aria-label={ui.paletteExpanded ? t("ai.collapse") : t("ai.expand")}
+          title={ui.paletteExpanded ? t("ai.collapse") : t("ai.expand")}
+        >
+          {#if ui.paletteExpanded}
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.3">
+              <path d="M6.5 5.5L10 2M10 2H7.5M10 2V4.5" />
+              <path d="M5.5 6.5L2 10M2 10H4.5M2 10V7.5" />
+            </svg>
+          {:else}
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.3">
+              <path d="M7 5L10.5 1.5M10.5 1.5H8M10.5 1.5V4" />
+              <path d="M5 7L1.5 10.5M1.5 10.5H4M1.5 10.5V8" />
+            </svg>
+          {/if}
+        </button>
         <div class="chat" bind:this={chatThreadEl}>
           {#each chat.turns as turn, ti (ti)}
             {#if turn.role === "user"}
@@ -484,6 +509,7 @@
     z-index: 100;
   }
   .panel {
+    position: relative;
     width: 620px;
     max-width: calc(100vw - 48px);
     max-height: 60vh;
@@ -495,6 +521,48 @@
     flex-direction: column;
     overflow: hidden;
     height: fit-content;
+  }
+  /* Expand/collapse is an instant state swap (like the sidebar rail), not an
+     animated resize — cheaper and jank-free for a full-height panel. */
+  .panel.expanded {
+    width: min(1100px, calc(100vw - 64px));
+    max-height: calc(100vh - 12vh - 48px);
+    height: calc(100vh - 12vh - 48px);
+  }
+  /* Keep answer text in a readable column instead of stretching it edge-to-edge. */
+  .panel.expanded .chat,
+  .panel.expanded .chat-followup {
+    padding-inline: max(20px, calc((100% - 760px) / 2));
+  }
+
+  .expand-toggle {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-s);
+    background: transparent;
+    color: var(--text-faint);
+    cursor: pointer;
+    transition:
+      background 0.12s ease,
+      color 0.12s ease;
+  }
+  .expand-toggle:hover {
+    background: var(--hover);
+    color: var(--accent);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .expand-toggle {
+      transition: none;
+    }
   }
 
   .input-row {
@@ -602,7 +670,9 @@
   .chat {
     flex: 1;
     min-height: 0;
-    padding: 18px;
+    /* Extra top padding reserves room for the floating expand toggle so it
+       never overlaps the first (right-aligned) message bubble. */
+    padding: 40px 18px 18px;
     display: flex;
     flex-direction: column;
     gap: 14px;

--- a/src/lib/stores/ui.svelte.ts
+++ b/src/lib/stores/ui.svelte.ts
@@ -22,6 +22,8 @@ const state = $state({
   shortcutsOpen: false,
   /** Left menu collapsed to an icon-only rail. */
   sidebarCollapsed: false,
+  /** Command-palette AI chat expanded to near-fullscreen. */
+  paletteExpanded: false,
 });
 
 /** Parse a persisted theme string into the two axes, migrating legacy values.
@@ -133,6 +135,18 @@ export const ui = {
   toggleSidebar() {
     state.sidebarCollapsed = !state.sidebarCollapsed;
     void api.setSetting("sidebar_collapsed", state.sidebarCollapsed ? "on" : "off").catch(() => {});
+  },
+  get paletteExpanded() {
+    return state.paletteExpanded;
+  },
+  /** Apply the expanded state without persisting (boot path). */
+  setPaletteExpanded(expanded: boolean) {
+    state.paletteExpanded = expanded;
+  },
+  /** Toggle the palette's expanded chat view and persist the choice. */
+  togglePaletteExpanded() {
+    state.paletteExpanded = !state.paletteExpanded;
+    void api.setSetting("palette_expanded", state.paletteExpanded ? "on" : "off").catch(() => {});
   },
   get readingAi() {
     return readingAi;


### PR DESCRIPTION
## Что и зачем

Command palette (Ctrl+K) умеет вести диалог с ИИ, но панель всегда оставалась маленькой коробкой (620px / 60vh) — тесно для чтения длинных ответов. Добавил возможность развернуть панель почти во весь экран, чтобы общаться было удобно.

## Поведение

- **Кнопка-тумблер** в правом верхнем углу — только в режиме чата (в поиске команд её нет, панель остаётся компактной). Иконка и `aria-label` (Expand/Collapse) меняются по состоянию.
- **Развёрнутый вид**: 1100px ширина + почти вся высота окна; текст ответов держится в читаемой колонке ~760px, а не растягивается edge-to-edge.
- **Повторный Ctrl+K** в чате переключает разворот и больше **не закрывает** палитру (App открывает идемпотентно через `palette.show()`; Esc и клик по фону по-прежнему закрывают).
- **Запоминается** между открытиями (через настройки, как `sidebar_collapsed`); применяется только в чате, так что поиск команд всегда компактный.
- Разворот **мгновенный** (не анимированный ресайз) — как у сайдбара: дешевле, без jank, и обходит баг Chromium, где анимация `width` до значения `min()` даёт неверный итоговый размер.

## Изменения

- `src/lib/stores/ui.svelte.ts` — состояние `paletteExpanded` + toggle с персистом.
- `src/App.svelte` — гидрация настройки; Ctrl+K → `palette.show()`.
- `src/components/CommandPalette.svelte` — кнопка-тумблер, класс `expanded`, CSS.
- `src-tauri/src/commands/settings.rs` — `palette_expanded` в allowlist `ALLOWED` (иначе персист молча не работает).

Новых i18n-ключей не потребовалось — переиспользованы существующие `ai.expand` / `ai.collapse`.

## Проверка

- ✅ `npm run check` (0 ошибок), `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` (80 passed).
- ✅ Прогон вживую в demo-харнесе: кнопка только в чате → разворот 1100×586 → колонка ровно 760px (гуттеры 169px) → нет наложения на первый пузырь → Ctrl+K сворачивает и не закрывает → Esc закрывает → в поиске панель компактна.

🤖 Generated with [Claude Code](https://claude.com/claude-code)