### PR TITLE
refactor(ai): follow-ups from the #16 review

### DIFF
--- a/src-tauri/src/ai/ollama.rs
+++ b/src-tauri/src/ai/ollama.rs
@@ -113,11 +113,16 @@ pub async fn list_models(base_url: &str) -> Result<Vec<Model>> {
         .collect::<Vec<_>>()
         .await;
 
+    let total = tags.models.len();
+    let mut reached = 0usize;
     let mut models = Vec::new();
     for (tag, resp) in tags.models.into_iter().zip(shows) {
-        let resp =
-            resp.map_err(|_| SkimError::other("ai_unreachable", "Ollama is not responding"))?;
-        // A model that errors on /api/show just doesn't get listed.
+        // A model that errors on /api/show (network or parse) just doesn't
+        // get listed; one flaky request shouldn't drop the whole picker.
+        let Ok(resp) = resp else {
+            continue;
+        };
+        reached += 1;
         let Ok(show) = resp.json::<ShowResponse>().await else {
             continue;
         };
@@ -127,6 +132,15 @@ pub async fn list_models(base_url: &str) -> Result<Vec<Model>> {
                 name: tag.name,
             });
         }
+    }
+    // Skipping is for individual flakes. If the server listed models but then
+    // answered none of the /api/show requests, it vanished mid-listing: that
+    // is "unreachable", not "no tool-capable models installed".
+    if total > 0 && reached == 0 {
+        return Err(SkimError::other(
+            "ai_unreachable",
+            "Ollama is not responding",
+        ));
     }
     Ok(models)
 }

--- a/src/components/AiRecap.svelte
+++ b/src/components/AiRecap.svelte
@@ -8,7 +8,7 @@
   import { aiLinks } from "../lib/ai-links";
   import { t } from "../lib/i18n/index.svelte";
   import { mdLite } from "../lib/md";
-  import { ai } from "../lib/stores/ai.svelte";
+  import { createSlowStart } from "../lib/slow-start.svelte";
   import { mail } from "../lib/stores/mail.svelte";
   import { ui } from "../lib/stores/ui.svelte";
 
@@ -49,22 +49,10 @@
   let followup = $state("");
   let cancelChat: (() => void) | null = null;
   let bodyEl: HTMLDivElement | undefined = $state();
-  // A custom endpoint's cold start can stall the first token for many seconds —
-  // after 5s of silence, say what is actually happening. Shared between the
-  // initial scan and the follow-up chat since only one of them can be in
-  // flight at a time (the chat only exists once the scan is done).
-  let slowStart = $state(false);
-  let slowTimer: ReturnType<typeof setTimeout> | undefined;
-  function armSlowStart() {
-    clearTimeout(slowTimer);
-    slowStart = false;
-    if (ai.provider !== "custom") return;
-    slowTimer = setTimeout(() => (slowStart = true), 5000);
-  }
-  function clearSlowStart() {
-    clearTimeout(slowTimer);
-    slowStart = false;
-  }
+  // Cold-start hint, shared between the initial scan and the follow-up chat
+  // since only one of them can be in flight at a time (the chat only exists
+  // once the scan is done).
+  const slowStart = createSlowStart();
 
   $effect(() => {
     const folderId = mail.selectedFolderId;
@@ -80,7 +68,7 @@
     progress = null;
     scannedTotal = 0;
     markedCount = 0;
-    clearSlowStart();
+    slowStart.clear();
     cancel = aiStream(
       "ai_recap",
       { folderId },
@@ -90,16 +78,16 @@
           if (total > scannedTotal) scannedTotal = total;
           // A cold model start can leave the counter frozen at N/N after the
           // scan itself finishes — re-arm on every progress tick.
-          armSlowStart();
+          slowStart.arm();
         },
         delta: (chunk) => {
-          clearSlowStart();
+          slowStart.clear();
           status = "streaming";
           progress = null;
           text += chunk;
         },
         done: (cited) => {
-          clearSlowStart();
+          slowStart.clear();
           status = "done";
           citations = cited;
           markRead(cited);
@@ -117,7 +105,7 @@
           };
         },
         error: (code, message) => {
-          clearSlowStart();
+          slowStart.clear();
           status = "error";
           text = code === "ai_key" ? t("ai.needs_key") : message;
         },
@@ -162,17 +150,17 @@
     const byIndex = new Map<number, Citation>();
     for (const tn of chat.turns) for (const c of tn.citations) byIndex.set(c.index, c);
     const priorCitations = [...byIndex.values()];
-    armSlowStart();
+    slowStart.arm();
     cancelChat = aiStream(
       "ai_chat",
       { turns: history, priorCitations, contextMessageId: null },
       {
         delta: (chunk) => {
-          clearSlowStart();
+          slowStart.clear();
           if (chat) chat.answer += chunk;
         },
         toolCall: (id, kind, arg) => {
-          clearSlowStart();
+          slowStart.clear();
           if (chat) chat.steps = [...chat.steps, { id, kind, arg, count: null, done: false }];
         },
         toolDone: (id, count) => {
@@ -180,7 +168,7 @@
             chat.steps = chat.steps.map((s) => (s.id === id ? { ...s, count, done: true } : s));
         },
         done: (cited) => {
-          clearSlowStart();
+          slowStart.clear();
           if (!chat) return;
           chat.turns = [...chat.turns, { role: "assistant", content: chat.answer, citations: cited }];
           chat.answer = "";
@@ -188,7 +176,7 @@
           chat.status = "done";
         },
         error: (code, message) => {
-          clearSlowStart();
+          slowStart.clear();
           if (!chat) return;
           // Drop the unanswered question back into the box so it can be retried.
           const last = chat.turns[chat.turns.length - 1];
@@ -238,7 +226,7 @@
     {#if status === "scanning"}
       <div class="progress">
         <span class="spinner"></span>
-        {#if slowStart}
+        {#if slowStart.slow}
           {t("ai.loading_model")}
         {:else}
           {t("ai.recap_reading")}
@@ -333,7 +321,7 @@
               <div class="chat-answer">
                 <div class="microlabel chat-label">✦ {t("ai.answer")}</div>
                 {#if chat.answer === ""}
-                  <span class="thinking">{slowStart ? t("ai.loading_model") : t("ai.thinking")}</span>
+                  <span class="thinking">{slowStart.slow ? t("ai.loading_model") : t("ai.thinking")}</span>
                 {:else}
                   <div class="chat-text md-body" use:aiLinks>{@html mdLite(chat.answer)}</div>
                 {/if}

--- a/src/components/CommandPalette.svelte
+++ b/src/components/CommandPalette.svelte
@@ -5,6 +5,7 @@
   import { aiLinks } from "../lib/ai-links";
   import { getLocale, t } from "../lib/i18n/index.svelte";
   import { mdLite } from "../lib/md";
+  import { createSlowStart } from "../lib/slow-start.svelte";
   import { ai } from "../lib/stores/ai.svelte";
   import { mail } from "../lib/stores/mail.svelte";
   import { palette } from "../lib/stores/palette.svelte";
@@ -47,20 +48,7 @@
   let followupEl: HTMLInputElement | undefined = $state();
   let chatThreadEl: HTMLDivElement | undefined = $state();
   let cancelChat: (() => void) | null = null;
-  // A custom endpoint's cold start can stall the first token for many seconds
-  // — after 5s of silence, say what is actually happening.
-  let slowStart = $state(false);
-  let slowTimer: ReturnType<typeof setTimeout> | undefined;
-  function armSlowStart() {
-    clearTimeout(slowTimer);
-    slowStart = false;
-    if (ai.provider !== "custom") return;
-    slowTimer = setTimeout(() => (slowStart = true), 5000);
-  }
-  function clearSlowStart() {
-    clearTimeout(slowTimer);
-    slowStart = false;
-  }
+  const slowStart = createSlowStart();
 
   function askChat(question: string) {
     cancelChat?.();
@@ -84,17 +72,17 @@
     const byIndex = new Map<number, Citation>();
     for (const tn of chat.turns) for (const c of tn.citations) byIndex.set(c.index, c);
     const priorCitations = [...byIndex.values()];
-    armSlowStart();
+    slowStart.arm();
     cancelChat = aiStream(
       "ai_chat",
       { turns: history, priorCitations, contextMessageId: chat.contextMessageId },
       {
         delta: (text) => {
-          clearSlowStart();
+          slowStart.clear();
           if (chat) chat.answer += text;
         },
         toolCall: (id, kind, arg) => {
-          clearSlowStart();
+          slowStart.clear();
           if (chat) chat.steps = [...chat.steps, { id, kind, arg, count: null, done: false }];
         },
         toolDone: (id, count) => {
@@ -102,7 +90,7 @@
             chat.steps = chat.steps.map((s) => (s.id === id ? { ...s, count, done: true } : s));
         },
         done: (citations) => {
-          clearSlowStart();
+          slowStart.clear();
           if (!chat) return;
           chat.turns = [...chat.turns, { role: "assistant", content: chat.answer, citations }];
           chat.answer = "";
@@ -111,7 +99,7 @@
           queueMicrotask(() => followupEl?.focus());
         },
         error: (code, message) => {
-          clearSlowStart();
+          slowStart.clear();
           if (!chat) return;
           // Drop the unanswered question back into the box so it can be retried.
           const last = chat.turns[chat.turns.length - 1];
@@ -147,7 +135,7 @@
     cancelChat = null;
     chat = null;
     followup = "";
-    clearSlowStart();
+    slowStart.clear();
     queueMicrotask(() => inputEl?.focus());
   }
 
@@ -247,7 +235,7 @@
       active = 0;
       chat = null;
       followup = "";
-      clearSlowStart();
+      slowStart.clear();
       queueMicrotask(() => inputEl?.focus());
     }
   });
@@ -415,7 +403,7 @@
             <div class="chat-answer">
               <div class="microlabel chat-label">✦ {t("ai.answer")}</div>
               {#if chat.answer === ""}
-                <span class="thinking">{slowStart ? t("ai.loading_model") : t("ai.thinking")}</span>
+                <span class="thinking">{slowStart.slow ? t("ai.loading_model") : t("ai.thinking")}</span>
               {:else}
                 <div class="chat-text md-body" use:aiLinks>{@html mdLite(chat.answer)}</div>
               {/if}

--- a/src/components/ComposeForm.svelte
+++ b/src/components/ComposeForm.svelte
@@ -3,8 +3,10 @@
   // its own native window (Composer.svelte, `chrome` on) and inline in the
   // reading pane for editing a draft from the Drafts folder (`chrome` off).
   import { onDestroy } from "svelte";
-  import { aiApi, aiStream, api, errorMessage, type AiProvider } from "../lib/api";
+  import { aiStream, api, errorMessage } from "../lib/api";
   import { t } from "../lib/i18n/index.svelte";
+  import { createSlowStart } from "../lib/slow-start.svelte";
+  import { ai } from "../lib/stores/ai.svelte";
   import type { Account, Draft, DraftAttachment } from "../lib/types";
   import AddressInput from "./AddressInput.svelte";
 
@@ -180,23 +182,7 @@
   });
   let aiBusy = $state(false);
   let cancelAi: (() => void) | null = null;
-  // The composer runs in its own window, where the shared `ai` store is never
-  // refreshed — track the provider from this component's own keyStatus fetch.
-  let aiProviderName = $state<AiProvider>("anthropic");
-  // A custom endpoint's cold start can stall the first token for many seconds
-  // — after 5s of silence, say what is actually happening.
-  let slowStart = $state(false);
-  let slowTimer: ReturnType<typeof setTimeout> | undefined;
-  function armSlowStart() {
-    clearTimeout(slowTimer);
-    slowStart = false;
-    if (aiProviderName !== "custom") return;
-    slowTimer = setTimeout(() => (slowStart = true), 5000);
-  }
-  function clearSlowStart() {
-    clearTimeout(slowTimer);
-    slowStart = false;
-  }
+  const slowStart = createSlowStart();
   /** Quoted original (reply/forward), preserved below AI-generated text. */
   let quotedTail = "";
 
@@ -227,12 +213,10 @@
     return { subject, body };
   }
 
+  // The composer runs in its own window with its own copy of the `ai` store;
+  // refresh it here so this webview sees the active provider and key too.
   $effect(() => {
-    void aiApi.keyStatus().then((s) => {
-      aiAvailable =
-        s.provider === "custom" ? s.custom : s.provider === "openrouter" ? s.openrouter : s.anthropic;
-      aiProviderName = s.provider;
-    });
+    void ai.refresh().then(() => (aiAvailable = ai.keyPresent));
   });
 
   function splitQuote(body: string): [string, string] {
@@ -277,7 +261,7 @@
     aiBusy = true;
     error = "";
     draft.body = quotedTail;
-    armSlowStart();
+    slowStart.arm();
     let streamed = "";
     // The pending instruction rides along with the settled history for the
     // request, but it isn't committed to `convo` until it succeeds — so a
@@ -295,7 +279,7 @@
       },
       {
         delta: (text) => {
-          clearSlowStart();
+          slowStart.clear();
           streamed += text;
           if (!draft) return;
           // Replies stream straight into the body; new mail has its subject
@@ -309,7 +293,7 @@
           draft.body = quotedTail ? `${body}\n${quotedTail}` : body;
         },
         done: () => {
-          clearSlowStart();
+          slowStart.clear();
           const text = streamed.trim();
           if (text) {
             // Success — commit the exchange to the session and (only now) clear
@@ -327,7 +311,7 @@
           scheduleSave();
         },
         error: (_code, message) => {
-          clearSlowStart();
+          slowStart.clear();
           aiBusy = false;
           error = message;
           // The instruction was never committed or cleared, so it's still in
@@ -375,7 +359,7 @@
   function stopAi() {
     cancelAi?.();
     aiBusy = false;
-    clearSlowStart();
+    slowStart.clear();
     // The pending instruction was never committed to the session, so it stays
     // put in the input — nothing to roll back.
   }
@@ -619,7 +603,7 @@
           <!-- Progress indicator: kept OUTSIDE the scrollable thread so a tall
                instruction can't push it below the fold — it must stay visible
                the whole time the draft is streaming. -->
-          <div class="ai-thinking">✦ {slowStart ? t("ai.loading_model") : t("ai.thinking")}</div>
+          <div class="ai-thinking">✦ {slowStart.slow ? t("ai.loading_model") : t("ai.thinking")}</div>
         {/if}
         <form
           class="ai-input"

--- a/src/components/ReadingPane.svelte
+++ b/src/components/ReadingPane.svelte
@@ -3,6 +3,7 @@
   import { aiLinks } from "../lib/ai-links";
   import { getLocale, t } from "../lib/i18n/index.svelte";
   import { mdLite } from "../lib/md";
+  import { createSlowStart } from "../lib/slow-start.svelte";
   import { ai } from "../lib/stores/ai.svelte";
   import { aiChat } from "../lib/stores/aiChat.svelte";
   import { mail } from "../lib/stores/mail.svelte";
@@ -40,20 +41,7 @@
   let askInput: HTMLInputElement | undefined = $state();
   let askThreadEl: HTMLDivElement | undefined = $state();
   let cancelAi: (() => void) | null = null;
-  // A custom endpoint's cold start can stall the first token for many seconds
-  // — after 5s of silence, say what is actually happening.
-  let slowStart = $state(false);
-  let slowTimer: ReturnType<typeof setTimeout> | undefined;
-  function armSlowStart() {
-    clearTimeout(slowTimer);
-    slowStart = false;
-    if (ai.provider !== "custom") return;
-    slowTimer = setTimeout(() => (slowStart = true), 5000);
-  }
-  function clearSlowStart() {
-    clearTimeout(slowTimer);
-    slowStart = false;
-  }
+  const slowStart = createSlowStart();
 
   // Close the dock. The completed turns stay in askTurns (and the cache), so
   // reopening — for this email or after hopping to another and back — restores
@@ -64,20 +52,20 @@
     askOpen = false;
     askExpanded = false;
     askQuestion = "";
-    clearSlowStart();
+    slowStart.clear();
   }
 
   function startAi(args: Record<string, unknown>) {
     cancelAi?.();
     aiPanel = { status: "streaming", text: "", steps: [] };
-    armSlowStart();
+    slowStart.arm();
     cancelAi = aiStream("ai_ask", args, {
       delta: (text) => {
-        clearSlowStart();
+        slowStart.clear();
         if (aiPanel) aiPanel = { ...aiPanel, text: aiPanel.text + text };
       },
       toolCall: (id, kind, arg) => {
-        clearSlowStart();
+        slowStart.clear();
         if (aiPanel)
           aiPanel = {
             ...aiPanel,
@@ -92,14 +80,14 @@
           };
       },
       done: () => {
-        clearSlowStart();
+        slowStart.clear();
         if (!aiPanel) return;
         askTurns.push({ role: "assistant", content: aiPanel.text });
         aiPanel = null;
         queueMicrotask(() => askInput?.focus());
       },
       error: (code, message) => {
-        clearSlowStart();
+        slowStart.clear();
         // Put the failed question back into the input so it can be retried.
         if (askTurns[askTurns.length - 1]?.role === "user") {
           askQuestion = askTurns.pop()!.content;
@@ -137,7 +125,7 @@
     cancelAi?.();
     aiPanel = null;
     askQuestion = "";
-    clearSlowStart();
+    slowStart.clear();
     askKey = id;
     askTurns = id === null ? [] : aiChat.get(id);
   });
@@ -624,7 +612,7 @@
                   </div>
                 {/if}
                 {#if aiPanel.text === "" && aiPanel.status === "streaming"}
-                  <span class="thinking">{slowStart ? t("ai.loading_model") : t("ai.thinking")}</span>
+                  <span class="thinking">{slowStart.slow ? t("ai.loading_model") : t("ai.thinking")}</span>
                 {:else}
                   <div class="ai-text md-body" use:aiLinks>{@html mdLite(aiPanel.text)}</div>
                 {/if}

--- a/src/components/onboarding/Onboarding.svelte
+++ b/src/components/onboarding/Onboarding.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { getVersion } from "@tauri-apps/api/app";
   import { openUrl } from "@tauri-apps/plugin-opener";
-  import { aiApi, api, errorMessage, type AiProvider, type OrModel } from "../../lib/api";
+  import { aiApi, api, errorMessage, type AiProvider } from "../../lib/api";
   import { getLocale, LOCALES, setLocale, t, type Locale } from "../../lib/i18n/index.svelte";
+  import { createOllamaDetection, ollamaV1 } from "../../lib/ollama-detect.svelte";
   import { mail } from "../../lib/stores/mail.svelte";
   import type { Account } from "../../lib/types";
   import ConnectForm from "./ConnectForm.svelte";
@@ -28,38 +29,12 @@
   let customModel = $state("");
   // Silent Ollama detection, mirroring Settings: an installed, tool-capable
   // catalog turns into clickable chips; any error just means an empty list.
-  let ollamaModels = $state<OrModel[]>([]);
-  let ollamaStatus = $state<"idle" | "some" | "none">("idle");
-  let ollamaGeneration = 0;
+  const ollama = createOllamaDetection(() => customBaseUrl);
 
   function chooseAiProvider(p: AiProvider) {
     aiProvider = p;
     aiError = "";
-    if (p === "custom") void detectOllama();
-  }
-
-  async function detectOllama() {
-    const url = customBaseUrl.trim();
-    if (!url) {
-      // Bump the generation here too, so a still-in-flight probe for the
-      // previous URL can't land afterwards and repaint chips for a field
-      // that's now empty.
-      ++ollamaGeneration;
-      ollamaModels = [];
-      ollamaStatus = "idle";
-      return;
-    }
-    const generation = ++ollamaGeneration;
-    try {
-      const models = await aiApi.ollamaModels(url);
-      if (generation !== ollamaGeneration) return;
-      ollamaModels = models;
-      ollamaStatus = models.length > 0 ? "some" : "none";
-    } catch {
-      if (generation !== ollamaGeneration) return;
-      ollamaModels = [];
-      ollamaStatus = "idle";
-    }
+    if (p === "custom") void ollama.detect();
   }
 
   async function accountConnected(account: Account) {
@@ -191,7 +166,7 @@
           <span class="microlabel">{t("settings.custom_base_url")}</span>
           <input
             bind:value={customBaseUrl}
-            onblur={detectOllama}
+            onblur={ollama.detect}
             placeholder={t("settings.custom_base_url_ph")}
             spellcheck="false"
             autocomplete="off"
@@ -210,11 +185,11 @@
             autocomplete="off"
           />
         </label>
-        {#if ollamaStatus === "some"}
+        {#if ollama.status === "some"}
           <div class="ai-key">
             <span class="microlabel">{t("settings.custom_models_detected")}</span>
             <div class="lang-row">
-              {#each ollamaModels as m (m.id)}
+              {#each ollama.models as m (m.id)}
                 <button
                   type="button"
                   class="lang"
@@ -224,10 +199,7 @@
                     customModel = m.id;
                     // The URL is known-good (detection succeeded) and the key
                     // is optional — a chip pick can finish the setup outright.
-                    // Ollama's OpenAI API lives under /v1; complete a bare root
-                    // so generation doesn't 404 later.
-                    const base = customBaseUrl.trim().replace(/\/+$/, "");
-                    customBaseUrl = base.endsWith("/v1") ? base : `${base}/v1`;
+                    customBaseUrl = ollamaV1(customBaseUrl);
                     void enableAi();
                   }}
                 >
@@ -236,7 +208,7 @@
               {/each}
             </div>
           </div>
-        {:else if ollamaStatus === "none"}
+        {:else if ollama.status === "none"}
           <div class="key-hint">{t("settings.custom_no_tool_models")}</div>
         {/if}
         <div class="key-hint">{t("settings.custom_hint")}</div>

--- a/src/components/settings/Settings.svelte
+++ b/src/components/settings/Settings.svelte
@@ -5,6 +5,7 @@
   import { aiApi, aiStream, api, errorMessage } from "../../lib/api";
   import type { AiProvider, OrModel } from "../../lib/api";
   import { LOCALES, getLocale, setLocale, t, type Locale } from "../../lib/i18n/index.svelte";
+  import { createOllamaDetection, ollamaV1 } from "../../lib/ollama-detect.svelte";
   import { ai } from "../../lib/stores/ai.svelte";
   import { mail } from "../../lib/stores/mail.svelte";
   import { ui } from "../../lib/stores/ui.svelte";
@@ -87,15 +88,9 @@
   let customBaseUrl = $state("");
   let customKey = $state("");
   let customModel = $state("");
-  // Silent Ollama detection for the custom tab: if the base URL turns out to
-  // belong to an Ollama server, its installed models become clickable chips.
-  // Any error (unreachable, not Ollama, …) just means an empty list — no error
-  // UI, per upstream's no-connectivity-probe philosophy for this provider.
-  let ollamaModels = $state<OrModel[]>([]);
-  let ollamaStatus = $state<"idle" | "some" | "none">("idle");
-  // Guards against a stale response landing after a newer request started
-  // (e.g. the user edits the URL again while the first lookup is in flight).
-  let ollamaGeneration = 0;
+  // Silent probe: does customBaseUrl belong to an Ollama server? Runs on tab
+  // entry and on base-URL blur.
+  const ollama = createOllamaDetection(() => customBaseUrl);
   let imagesPolicy = $state("block");
   let notifications = $state("on");
   let groupThreads = $state("on");
@@ -136,7 +131,7 @@
       // the effect's tracked scope — this runs inside the .then() continuation
       // of an already-resolved async call, after the effect itself has finished
       // running, so it registers no reactive dependencies.
-      if (providerTab === "custom" && customBaseUrl.trim()) void detectOllama();
+      if (providerTab === "custom") void ollama.detect();
       if (s.custom_model) customModel = s.custom_model;
       if (s.images_policy) imagesPolicy = s.images_policy;
       if (s.notifications) notifications = s.notifications;
@@ -262,53 +257,17 @@
       await api.setSetting("ai_provider", p);
       await ai.refresh();
     }
-    if (p === "custom") void detectOllama();
-  }
-
-  // Silent probe: does customBaseUrl belong to an Ollama server? Runs on tab
-  // entry and on base-URL blur. Never surfaces an error — an unreachable or
-  // non-Ollama endpoint is exactly what upstream's design expects, and this is
-  // purely an enhancement on top of it.
-  async function detectOllama() {
-    const url = customBaseUrl.trim();
-    if (!url) {
-      // Bump the generation here too, so a still-in-flight probe for the
-      // previous URL can't land afterwards and repaint chips for a field
-      // that's now empty.
-      ++ollamaGeneration;
-      ollamaModels = [];
-      ollamaStatus = "idle";
-      return;
-    }
-    const generation = ++ollamaGeneration;
-    try {
-      const models = await aiApi.ollamaModels(url);
-      if (generation !== ollamaGeneration) return;
-      ollamaModels = models;
-      ollamaStatus = models.length > 0 ? "some" : "none";
-    } catch {
-      if (generation !== ollamaGeneration) return;
-      ollamaModels = [];
-      ollamaStatus = "idle";
-    }
+    if (p === "custom") void ollama.detect();
   }
 
   // A hand-typed model the detected server doesn't announce as tool-capable:
   // either a typo, or an installed model that can't drive the mailbox chat.
   // Warn, don't block — compose-only use of such a model is legitimate.
   const customModelUnknown = $derived(
-    ollamaStatus === "some" &&
+    ollama.status === "some" &&
       customModel.trim().length > 0 &&
-      !ollamaModels.some((m) => m.id === customModel.trim()),
+      !ollama.models.some((m) => m.id === customModel.trim()),
   );
-
-  // Detection proved the URL is an Ollama server, whose OpenAI API lives
-  // under /v1 — complete a bare root so generation doesn't 404 later
-  // (upstream deliberately keeps the user's input literal otherwise).
-  function ollamaV1(url: string): string {
-    const base = url.trim().replace(/\/+$/, "");
-    return base.endsWith("/v1") ? base : `${base}/v1`;
-  }
 
   // A chip pick fills the field. In the configured state it persists like
   // saveCustomModel's save-on-commit; in the setup form it completes the whole
@@ -463,7 +422,7 @@
       customBaseUrl = "";
       customModel = "";
       // Blank-URL branch: drops the chips and voids any in-flight probe.
-      void detectOllama();
+      void ollama.detect();
     }
     await ai.refresh();
   }
@@ -524,11 +483,11 @@
      save-on-commit for the model field (the setup form saves everything
      together via saveCustom). -->
 {#snippet ollamaChips(persist: boolean)}
-  {#if ollamaStatus === "some"}
+  {#if ollama.status === "some"}
     <div class="writer-field">
       <span class="microlabel">{t("settings.custom_models_detected")}</span>
       <div class="chips">
-        {#each ollamaModels as m (m.id)}
+        {#each ollama.models as m (m.id)}
           <button
             type="button"
             class="model"
@@ -543,7 +502,7 @@
         <span class="dim hint">{t("settings.custom_model_unknown")}</span>
       {/if}
     </div>
-  {:else if ollamaStatus === "none"}
+  {:else if ollama.status === "none"}
     <span class="dim hint">{t("settings.custom_no_tool_models")}</span>
   {/if}
 {/snippet}
@@ -901,7 +860,7 @@
               <span class="microlabel">{t("settings.custom_base_url")}</span>
               <input
                 bind:value={customBaseUrl}
-                onblur={detectOllama}
+                onblur={ollama.detect}
                 placeholder={t("settings.custom_base_url_ph")}
                 spellcheck="false"
                 autocomplete="off"

--- a/src/components/settings/Settings.svelte
+++ b/src/components/settings/Settings.svelte
@@ -3,7 +3,7 @@
   import { disable, enable, isEnabled } from "@tauri-apps/plugin-autostart";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import { aiApi, aiStream, api, errorMessage } from "../../lib/api";
-  import type { AiProvider, OrModel } from "../../lib/api";
+  import type { AiModel, AiProvider } from "../../lib/api";
   import { LOCALES, getLocale, setLocale, t, type Locale } from "../../lib/i18n/index.svelte";
   import { createOllamaDetection, ollamaV1 } from "../../lib/ollama-detect.svelte";
   import { ai } from "../../lib/stores/ai.svelte";
@@ -81,7 +81,7 @@
   let orCustom = $state("");
   // OpenRouter's live catalog, so the field can't be set to a model that
   // doesn't exist. Empty until fetched — and if the fetch fails, forever.
-  let orModels = $state<OrModel[]>([]);
+  let orModels = $state<AiModel[]>([]);
   let orCustomOpen = $state(false);
   let orHighlight = $state(0);
   // The user-supplied OpenAI-compatible endpoint.

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -175,8 +175,9 @@ export interface AiKeyStatus {
   custom: boolean;
 }
 
-/** A model from OpenRouter's live catalog. */
-export interface OrModel {
+/** A pickable model: an OpenRouter catalog entry, or an Ollama server's
+ *  installed model (where both fields carry the tag). */
+export interface AiModel {
   id: string;
   name: string;
 }
@@ -188,10 +189,10 @@ export const aiApi = {
     invoke<void>("ai_set_custom", { baseUrl, key, model }),
   keyStatus: () => invoke<AiKeyStatus>("ai_key_status"),
   clearKey: (provider: AiProvider) => invoke<void>("ai_clear_key", { provider }),
-  orModels: () => invoke<OrModel[]>("openrouter_models"),
+  orModels: () => invoke<AiModel[]>("openrouter_models"),
   /** Installed models on an Ollama server, if the given (custom-provider) base
    *  URL turns out to be one — any error means "not Ollama", handled by the caller. */
-  ollamaModels: (url: string) => invoke<OrModel[]>("ollama_models", { url }),
+  ollamaModels: (url: string) => invoke<AiModel[]>("ollama_models", { url }),
 };
 
 /** Start a streaming AI request. Returns a cancel function. */

--- a/src/lib/ollama-detect.svelte.ts
+++ b/src/lib/ollama-detect.svelte.ts
@@ -1,4 +1,4 @@
-import { aiApi, type OrModel } from "./api";
+import { aiApi, type AiModel } from "./api";
 
 /**
  * Detection proved the URL is an Ollama server, whose OpenAI API lives under
@@ -18,7 +18,7 @@ export function ollamaV1(url: string): string {
  * philosophy for this provider.
  */
 export function createOllamaDetection(getUrl: () => string) {
-  let models = $state<OrModel[]>([]);
+  let models = $state<AiModel[]>([]);
   let status = $state<"idle" | "some" | "none">("idle");
   // Guards against a stale response landing after a newer request started
   // (e.g. the user edits the URL again while the first lookup is in flight).

--- a/src/lib/ollama-detect.svelte.ts
+++ b/src/lib/ollama-detect.svelte.ts
@@ -1,0 +1,60 @@
+import { aiApi, type OrModel } from "./api";
+
+/**
+ * Detection proved the URL is an Ollama server, whose OpenAI API lives under
+ * /v1: complete a bare root so generation doesn't 404 later (upstream
+ * deliberately keeps the user's input literal otherwise).
+ */
+export function ollamaV1(url: string): string {
+  const base = url.trim().replace(/\/+$/, "");
+  return base.endsWith("/v1") ? base : `${base}/v1`;
+}
+
+/**
+ * Silent Ollama detection for the custom (OpenAI-compatible) provider: if the
+ * base URL turns out to belong to an Ollama server, its installed tool-capable
+ * models become clickable chips. Any error (unreachable, not Ollama, …) just
+ * means an empty list: no error UI, per upstream's no-connectivity-probe
+ * philosophy for this provider.
+ */
+export function createOllamaDetection(getUrl: () => string) {
+  let models = $state<OrModel[]>([]);
+  let status = $state<"idle" | "some" | "none">("idle");
+  // Guards against a stale response landing after a newer request started
+  // (e.g. the user edits the URL again while the first lookup is in flight).
+  let generation = 0;
+
+  async function detect() {
+    const url = getUrl().trim();
+    if (!url) {
+      // Bump the generation here too, so a still-in-flight probe for the
+      // previous URL can't land afterwards and repaint chips for a field
+      // that's now empty.
+      ++generation;
+      models = [];
+      status = "idle";
+      return;
+    }
+    const gen = ++generation;
+    try {
+      const found = await aiApi.ollamaModels(url);
+      if (gen !== generation) return;
+      models = found;
+      status = found.length > 0 ? "some" : "none";
+    } catch {
+      if (gen !== generation) return;
+      models = [];
+      status = "idle";
+    }
+  }
+
+  return {
+    get models() {
+      return models;
+    },
+    get status() {
+      return status;
+    },
+    detect,
+  };
+}

--- a/src/lib/slow-start.svelte.ts
+++ b/src/lib/slow-start.svelte.ts
@@ -1,0 +1,27 @@
+import { ai } from "./stores/ai.svelte";
+
+/**
+ * A custom endpoint's cold start can stall the first token for many seconds:
+ * after 5s of silence, say what is actually happening. Only the custom
+ * (OpenAI-compatible, often local) provider warrants the hint; cloud
+ * providers answer fast or fail fast. The provider is read at arm time.
+ */
+export function createSlowStart() {
+  let slow = $state(false);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return {
+    get slow() {
+      return slow;
+    },
+    arm() {
+      clearTimeout(timer);
+      slow = false;
+      if (ai.provider !== "custom") return;
+      timer = setTimeout(() => (slow = true), 5000);
+    },
+    clear() {
+      clearTimeout(timer);
+      slow = false;
+    },
+  };
+}


### PR DESCRIPTION
Follow-ups to the review notes on #16, one commit per note.

> The `slowStart` timer is copy-pasted into four components (…) this wants to be a tiny shared helper in a `.svelte.ts` (a factory returning `{ arm, clear, get slow }` would do it). Same goes for `detectOllama`, duplicated between `Settings` and `Onboarding`.

Done, with exactly that shape: `createSlowStart` (`src/lib/slow-start.svelte.ts`) and `createOllamaDetection` (`src/lib/ollama-detect.svelte.ts`). While deduplicating I also moved the `/v1` URL completion there (Onboarding had its own inline copy buried in markup), and ComposeForm now populates its window's copy of the `ai` store via `ai.refresh()` instead of re-deriving keyStatus by hand, which let the helper read the store directly instead of taking a callback.

> `ollama.rs`: the comment and the code disagree on per-model failures. (…) A `continue` there would match the comment and the additive-only philosophy better.

Done: a model whose `/api/show` request fails is now skipped instead of dropping the whole list. One nuance surfaced while fixing it: if the server listed models but then answered none of the `/api/show` requests (it died mid-listing), returning an empty list would make the UI claim "no tool-capable models installed", which would be false. That case now reports `ai_unreachable`, so the UI stays silent as designed.

> Reusing `OrModel` for Ollama entries works, but the name now lies a little (…)

Renamed to `AiModel`.

Left out on purpose, per your notes: the `ai_unreachable` frontend distinction (still just documentation) and the `ollama pull qwen3` locale string ("we may swap it later").

Testing: `cargo fmt --check`, `cargo clippy -D warnings`, `cargo test` (97 passed), `npm run check`: all green. Each commit builds and type-checks on its own.

Thanks for the warm welcome on #16 and for letting me chip in on Skim: it's a pleasure to contribute to a project with this kind of focus.
