### PR TITLE
docs: switch the Product Hunt badge to the review widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Grab <code>Skim_x.y.z_x64-setup.exe</code> from the latest release</sub>
 
 <br>
 
-<a href="https://www.producthunt.com/products/skim-5?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-skim-7" target="_blank" rel="noopener noreferrer">
+<a href="https://www.producthunt.com/products/skim-5/reviews/new?utm_source=badge-product_review&utm_medium=badge&utm_source=badge-skim-5" target="_blank" rel="noopener noreferrer">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1201330&theme=dark&t=1784560252686">
-    <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1201330&theme=light&t=1784560252686" alt="Skim - Free, open-source AI email client for Windows | Product Hunt" width="250" height="54">
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1273953&theme=dark">
+    <img src="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1273953&theme=light" alt="Skim - Free, open-source AI email client for Windows | Product Hunt" width="250" height="54">
   </picture>
 </a>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -131,8 +131,8 @@
             <div class="dek-cta">
               <a class="btn-zine" href="https://github.com/nikserg/skim/releases/latest" data-i18n="hero_cta_download">↓ Download for Windows</a>
               <span class="cta-side">
-                <a class="ph-badge" href="https://www.producthunt.com/products/skim-5?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-skim-7" target="_blank" rel="noopener noreferrer" aria-label="Skim on Product Hunt">
-                  <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1201330&amp;theme=light&amp;t=1784560252686" alt="Skim - Free, open-source AI email client for Windows | Product Hunt" width="250" height="54" loading="lazy" decoding="async">
+                <a class="ph-badge" href="https://www.producthunt.com/products/skim-5/reviews/new?utm_source=badge-product_review&amp;utm_medium=badge&amp;utm_source=badge-skim-5" target="_blank" rel="noopener noreferrer" aria-label="Review Skim on Product Hunt">
+                  <img src="https://api.producthunt.com/widgets/embed-image/v1/product_review.svg?product_id=1273953&amp;theme=light" alt="Skim - Free, open-source AI email client for Windows | Product Hunt" width="250" height="54" loading="lazy" decoding="async">
                 </a>
                 <a class="link-marker" href="https://github.com/nikserg/skim" data-i18n="hero_cta_github">view the source →</a>
               </span>


### PR DESCRIPTION
Меняет бейдж Product Hunt на README и на лендинге с «featured» на виджет отзыва (`product_review.svg`), ссылка ведёт на форму отзыва.

- [README.md](README.md) — `<picture>` с light/dark сохранён, dark-вариант просто с `theme=dark`.
- [docs/index.html](docs/index.html) — лендинг всегда светлый (paper zine), поэтому только `theme=light`; `aria-label` уточнён до «Review Skim on Product Hunt», т.к. ссылка теперь ведёт на форму отзыва.

Проверено в браузере: картинка отдаётся, 250×54, ссылка резолвится.

Примечание: в исходном сниппете от Product Hunt дважды указан `utm_source` — оставлено как есть.

🤖 Generated with [Claude Code](https://claude.com/claude-code)