### PR TITLE
fix(mail): reconnect and retry when the body-fetch socket went stale

### DIFF
--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -33,6 +33,11 @@ const IDLE_REISSUE: std::time::Duration = std::time::Duration::from_secs(25 * 60
 // Ceiling on the actual body FETCH from the server, so a stalled socket can't
 // wedge the worker (and thus every later command) indefinitely.
 const BODY_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+// Shorter leash for the first try on a connection that has been sitting idle
+// since the last message was opened. A connection the server dropped usually
+// errors at once, but one killed by sleep/wake or a network switch just hangs —
+// and the reconnect below still has to fit inside BODY_FETCH_WAIT.
+const STALE_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 // How long a `get_message_body` caller waits for the worker to service its
 // request — longer than BODY_FETCH_TIMEOUT so the worker's own error wins, but
 // still bounded in case the worker is stuck on some other un-timed op.
@@ -144,9 +149,35 @@ pub fn spawn(app: AppHandle, db: Db, account: Account, data_dir: PathBuf) -> Syn
                         message_pk,
                         respond,
                     } => {
-                        let result = fetcher.fetch_body(message_pk).await;
-                        if result.is_err() {
+                        // Nothing else ever touches this connection, so between
+                        // two opened messages it can sit idle long enough for
+                        // the server to drop it — and we only find out when the
+                        // user clicks. Reconnect and try once more, so a socket
+                        // that merely went stale never reaches the reading pane
+                        // as "couldn't load".
+                        let reused = fetcher.session.is_some();
+                        let leash = if reused {
+                            STALE_FETCH_TIMEOUT
+                        } else {
+                            BODY_FETCH_TIMEOUT
+                        };
+                        let mut result = fetcher.fetch_body(message_pk, leash).await;
+                        if let Err(e) = &result {
                             fetcher.reset_session();
+                            // Only a reused connection is worth a second try:
+                            // reset_session() means the retry logs in fresh, so
+                            // this can't loop, and a failure that already
+                            // happened on a fresh connection is a real error.
+                            if reused {
+                                tracing::warn!(message_pk, error = %e, "body fetch failed on a reused session, reconnecting");
+                                result = fetcher.fetch_body(message_pk, BODY_FETCH_TIMEOUT).await;
+                                if result.is_err() {
+                                    fetcher.reset_session();
+                                }
+                            }
+                        }
+                        if let Err(e) = &result {
+                            tracing::warn!(message_pk, error = %e, "body fetch failed");
                         }
                         let _ = respond.send(result);
                     }
@@ -973,7 +1004,9 @@ impl Engine {
 
     // ---- bodies --------------------------------------------------------
 
-    async fn fetch_body(&mut self, message_pk: i64) -> Result<()> {
+    /// `timeout` bounds the FETCH itself; the caller picks it from how much it
+    /// trusts the connection (see the fetch worker in [`spawn`]).
+    async fn fetch_body(&mut self, message_pk: i64, timeout: std::time::Duration) -> Result<()> {
         let coords: Option<(String, u32, i64)> = self
             .db
             .call(move |conn| {
@@ -997,7 +1030,7 @@ impl Engine {
 
         self.ensure_selected(&imap_name).await?;
         let session = self.session().await?;
-        let raw: Option<Vec<u8>> = tokio::time::timeout(BODY_FETCH_TIMEOUT, async {
+        let raw: Option<Vec<u8>> = tokio::time::timeout(timeout, async {
             let mut stream = session
                 .uid_fetch(uid.to_string(), "(UID BODY.PEEK[])")
                 .await

--- a/src/components/ReadingPane.svelte
+++ b/src/components/ReadingPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { aiErrorText, aiStream, api } from "../lib/api";
+  import { aiErrorText, aiStream, api, errorMessage } from "../lib/api";
   import { aiLinks } from "../lib/ai-links";
   import { getLocale, t } from "../lib/i18n/index.svelte";
   import { mdLite } from "../lib/md";
@@ -172,6 +172,13 @@
 
   let detail = $state<ThreadDetail | null>(null);
   let bodies = $state<Record<number, RenderedBody | "loading" | "error">>({});
+  // Why a body failed, for the tooltip on the error note — the visible wording
+  // stays the same, but a bug report is diagnosable.
+  let bodyErrors = $state<Record<number, string>>({});
+  // Newest body request per message, so a slow answer can't overwrite a newer
+  // one. Plain (non-reactive) state: it only gates writes into `bodies`.
+  let bodySeq = 0;
+  const bodyReq = new Map<number, number>();
   // Real destination of the link under the cursor (browser-style status bar).
   let hoverUrl = $state<string | null>(null);
 
@@ -320,6 +327,8 @@
   async function loadThread(threadId: number) {
     detail = null;
     bodies = {};
+    bodyErrors = {};
+    bodyReq.clear();
     cancelAi?.();
     aiPanel = null;
     askOpen = false;
@@ -354,12 +363,26 @@
   }
 
   async function loadBody(messageId: number, showImages?: boolean) {
+    // A body fetch can take seconds (the server may have to be asked), so guard
+    // against both ways a late answer can land in the wrong place: the thread
+    // changed under us (loadThread clears `bodies`), or this same message was
+    // requested again meanwhile (a thread refresh, Retry, "show images"). An
+    // "error" written by a stale answer would latch — the auto-load effect only
+    // fires on `undefined`, so nothing would ever retry it.
+    const threadId = mail.selectedThreadId;
+    const seq = ++bodySeq;
+    bodyReq.set(messageId, seq);
+    const stale = () => bodyReq.get(messageId) !== seq || mail.selectedThreadId !== threadId;
     bodies = { ...bodies, [messageId]: "loading" };
     try {
       const body = await api.getMessageBody(messageId, showImages);
+      if (stale()) return;
       bodies = { ...bodies, [messageId]: body };
-    } catch {
+    } catch (e) {
+      console.warn("getMessageBody failed", messageId, e);
+      if (stale()) return;
       bodies = { ...bodies, [messageId]: "error" };
+      bodyErrors = { ...bodyErrors, [messageId]: errorMessage(e) };
     }
   }
 
@@ -710,7 +733,7 @@
     {#if body === "loading" || body === undefined}
       <div class="body-note">{t("reading.loading")}</div>
     {:else if body === "error"}
-      <div class="body-note">
+      <div class="body-note" title={bodyErrors[message.id]}>
         {t("reading.load_failed")}
         <button class="linkish" onclick={() => loadBody(message.id)}>{t("reading.retry")}</button>
       </div>


### PR DESCRIPTION
## Проблема

При открытии письма иногда появляется «Не удалось загрузить письмо» с кнопкой «Повторить» — и по кнопке письмо обычно открывается.

`f4ce384` перенёс загрузку тел писем на **отдельное IMAP-соединение**, и больше его ничто не трогает: только открытие некэшированного письма. Между открытиями сервер успевает его закрыть (или сокет умирает после сна/смены сети), а узнаём мы об этом ровно в момент клика. Дальше `reset_session()` — поэтому повтор и работает: сессия уже сброшена, и вторая попытка логинится заново.

Раньше эти фетчи шли по соединению воркера синхронизации, которое поллинг (300 с) и IDLE держат в тонусе. `8ca9172` (бэкофилл истории) сделал баг заметным: в списке теперь вся история, так что писем без кэшированного тела стало гораздо больше.

## Что сделано

**`src-tauri/src/mail/sync.rs`** — переподключение делаем сами: один тихий повтор, если попытка шла по переиспользованному соединению. `reused` — и защита от цикла (после сброса вторая попытка всегда «свежая»), и от бессмысленных ретраев настоящих ошибок сервера. Первой попытке на «отлежавшемся» сокете дан короткий поводок `STALE_FETCH_TIMEOUT` = 20 с: half-open сокет не падает, а висит, а переподключение обязано уложиться в `BODY_FETCH_WAIT` = 120 с. Обе ветки ошибок теперь логируются — до сих пор они не писались никуда.

**`src/components/ReadingPane.svelte`** — панель чтения умела защёлкивать эту ошибку: `loadBody` писал результат вслепую, поэтому ответ, пришедший после смены треда (который чистит `bodies`) или после повторного запроса того же письма, попадал не в ту карту — и починить это могла только кнопка, потому что эффект автозагрузки срабатывает лишь на `undefined`. Закрыты оба случая. Причина ошибки, которую раньше просто проглатывал `catch {}`, уезжает в тултип плашки; видимый текст не изменился, новых строк локализации нет.

## Проверка

- `npm run check`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (147 passed) — зелёные.
- Живьём в demo-харнесе с подставной ошибкой: плашка показывает прежний текст, в тултипе — реальная причина от бэкенда; «Повторить» рисует письмо; протухший отказ от предыдущего треда не портит открытый тред.
- Собрано в release и установлено локально — приложение поднимается, паники нет.

Не воспроизводилось вживую: собственно повтор в Rust (нужен реальный ящик и разрыв соединения — в `tauri dev` срабатывание видно по строке `body fetch failed on a reused session, reconnecting`) и случай «тот же тред обновился, пока тело грузилось» — там гарантия из кода (счётчик запросов), а не из наблюдения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)