### PR TITLE
fix(ai): stop calling a reasoning model "loading" while it thinks

### DIFF
--- a/src-tauri/src/ai/agent.rs
+++ b/src-tauri/src/ai/agent.rs
@@ -386,10 +386,10 @@ fn tools_for(provider: &Provider, set: ToolSet) -> Vec<Value> {
 
 // ---- the loop -------------------------------------------------------------
 
-/// Run the agent. Streams answer text via `on_delta`, and a per-tool trace via
-/// `on_tool_call` (id, kind `"search"`/`"read"`, human arg) and `on_tool_done`
-/// (id, email count for searches). Returns the emails actually cited in the
-/// answer.
+/// Run the agent. Streams answer text via `on_delta`, reports thinking via
+/// `on_reasoning`, and a per-tool trace via `on_tool_call` (id, kind
+/// `"search"`/`"read"`, human arg) and `on_tool_done` (id, email count for
+/// searches). Returns the emails actually cited in the answer.
 /// The conversation so far, oldest first. `role` is "user" or "assistant";
 /// the last turn is the question this run answers, earlier ones are history.
 #[allow(clippy::too_many_arguments)]
@@ -404,6 +404,7 @@ pub async fn run(
     tool_set: ToolSet,
     deps: AgentDeps,
     on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
     on_tool_call: &impl Fn(&str, &str, &str),
     on_tool_done: &impl Fn(&str, Option<u32>),
 ) -> Result<Vec<Citation>> {
@@ -500,6 +501,7 @@ pub async fn run(
             &media,
             tools,
             on_delta,
+            on_reasoning,
             &mut full_text,
         )
         .await?;
@@ -581,6 +583,7 @@ async fn call_provider(
     media: &[MediaBlock],
     tools: Vec<Value>,
     on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
     full_text: &mut String,
 ) -> Result<AssistantTurn> {
     let mut sink = |d: &str| {
@@ -596,7 +599,7 @@ async fn call_provider(
                 tools,
                 max_tokens: AGENT_MAX_TOKENS,
             };
-            anthropic::stream_tools(key, &req, &mut sink).await
+            anthropic::stream_tools(key, &req, &mut sink, on_reasoning).await
         }
         Provider::OpenAiCompat(ep) => {
             // No native attachment path here; media rides as extracted text
@@ -608,7 +611,7 @@ async fn call_provider(
                 tools,
                 max_tokens: AGENT_MAX_TOKENS,
             };
-            openai_compat::stream_tools(ep, key, &req, &mut sink).await
+            openai_compat::stream_tools(ep, key, &req, &mut sink, on_reasoning).await
         }
     }
 }

--- a/src-tauri/src/ai/anthropic.rs
+++ b/src-tauri/src/ai/anthropic.rs
@@ -97,8 +97,13 @@ pub async fn validate_key(key: &str) -> Result<()> {
 ///
 /// Thinking is reported on the *arrival* of a reasoning block, not on its
 /// contents: the API only returns the reasoning text when a request asks for
-/// it (`thinking.display`), and the current models think by default, so the
-/// blocks routinely arrive empty. Their arrival is the signal.
+/// it (`thinking.display`), so the blocks routinely arrive empty. Their
+/// arrival is the signal.
+///
+/// Whether one arrives at all is up to the model. We never send a `thinking`
+/// parameter, so only the tier that reasons by default (Claude 5, hence
+/// [`DEFAULT_MODEL`]) opens such a block. An older model opens none and nothing
+/// is reported, which is exactly the behaviour we had before.
 pub async fn stream(
     key: &str,
     request: &Request,

--- a/src-tauri/src/ai/anthropic.rs
+++ b/src-tauri/src/ai/anthropic.rs
@@ -91,16 +91,23 @@ pub async fn validate_key(key: &str) -> Result<()> {
     }
 }
 
-/// Stream a completion, invoking `on_delta` for each text fragment.
+/// Stream a completion, invoking `on_delta` for each text fragment and
+/// `on_reasoning` while the model thinks before it answers.
 /// Returns the stop reason. Honors one retry on 429/529.
+///
+/// Thinking is reported on the *arrival* of a reasoning block, not on its
+/// contents: the API only returns the reasoning text when a request asks for
+/// it (`thinking.display`), and the current models think by default, so the
+/// blocks routinely arrive empty. Their arrival is the signal.
 pub async fn stream(
     key: &str,
     request: &Request,
     mut on_delta: impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
 ) -> Result<Option<String>> {
     let mut attempt = 0;
     loop {
-        match stream_once(key, request, &mut on_delta).await {
+        match stream_once(key, request, &mut on_delta, on_reasoning).await {
             Err(e) if e.code() == "ai_overloaded" && attempt == 0 => {
                 attempt = 1;
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -114,6 +121,7 @@ async fn stream_once(
     key: &str,
     request: &Request,
     on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
 ) -> Result<Option<String>> {
     let body = json!({
         "model": request.model,
@@ -163,34 +171,63 @@ async fn stream_once(
                 let Some(data) = line.strip_prefix("data:") else {
                     continue;
                 };
-                let Ok(event) = serde_json::from_str::<SseEvent>(data.trim()) else {
-                    continue;
-                };
-                match event {
-                    SseEvent::ContentBlockDelta { delta } => {
-                        if let Some(text) = delta.text {
-                            on_delta(&text);
-                        }
-                    }
-                    SseEvent::MessageDelta { delta } => {
-                        if let Some(reason) = delta.stop_reason {
-                            stop_reason = Some(reason);
-                        }
-                    }
-                    SseEvent::Error { error } => {
-                        return Err(SkimError::other("ai", error.message));
-                    }
-                    SseEvent::Other => {}
-                }
+                apply_text_sse(data.trim(), &mut stop_reason, on_delta, on_reasoning)?;
             }
         }
     }
     Ok(stop_reason)
 }
 
+/// Fold one SSE payload into this round's state. Unparseable frames are
+/// skipped: the stream stays useful across schema additions. Split out of the
+/// socket loop so the parsing can be tested on its own, the way `apply_sse`
+/// already is for the tool path.
+fn apply_text_sse(
+    data: &str,
+    stop_reason: &mut Option<String>,
+    on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
+) -> Result<()> {
+    let Ok(event) = serde_json::from_str::<SseEvent>(data) else {
+        return Ok(());
+    };
+    match event {
+        // A thinking model reasons before it answers. The block's arrival is
+        // the whole signal: its text is empty unless the request asked for it.
+        SseEvent::ContentBlockStart { content_block } => {
+            if content_block.is_reasoning() {
+                on_reasoning();
+            }
+        }
+        SseEvent::ContentBlockDelta { delta } => {
+            if let Some(text) = delta.text {
+                on_delta(&text);
+            }
+            // Recovers the signal from a reasoning delta that arrives before
+            // its start frame.
+            if delta.thinking.is_some() {
+                on_reasoning();
+            }
+        }
+        SseEvent::MessageDelta { delta } => {
+            if let Some(reason) = delta.stop_reason {
+                *stop_reason = Some(reason);
+            }
+        }
+        SseEvent::Error { error } => {
+            return Err(SkimError::other("ai", error.message));
+        }
+        SseEvent::Other => {}
+    }
+    Ok(())
+}
+
 #[derive(Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum SseEvent {
+    ContentBlockStart {
+        content_block: BlockStart,
+    },
     ContentBlockDelta {
         delta: Delta,
     },
@@ -204,10 +241,30 @@ enum SseEvent {
     Other,
 }
 
+/// Only the kind of an opening block matters on this path: answer text arrives
+/// as deltas, and reasoning text is never rendered.
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum BlockStart {
+    Thinking,
+    RedactedThinking,
+    #[serde(other)]
+    Other,
+}
+
+impl BlockStart {
+    fn is_reasoning(&self) -> bool {
+        matches!(self, BlockStart::Thinking | BlockStart::RedactedThinking)
+    }
+}
+
 #[derive(Deserialize)]
 struct Delta {
     #[serde(default)]
     text: Option<String>,
+    /// `thinking_delta` fragments, never rendered: only their arrival is used.
+    #[serde(default)]
+    thinking: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -235,16 +292,18 @@ pub struct ToolRequest {
 }
 
 /// Stream one assistant round that may include tool calls. Text is streamed to
-/// `on_delta`; `tool_use` blocks are accumulated and returned. One retry on
-/// 429/529 (before any bytes stream, so no double-emit).
+/// `on_delta` and reasoning is reported through `on_reasoning` (see [`stream`]);
+/// `tool_use` blocks are accumulated and returned. One retry on 429/529 (before
+/// any bytes stream, so no double-emit).
 pub async fn stream_tools(
     key: &str,
     request: &ToolRequest,
     on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
 ) -> Result<AssistantTurn> {
     let mut attempt = 0;
     loop {
-        match stream_tools_once(key, request, on_delta).await {
+        match stream_tools_once(key, request, on_delta, on_reasoning).await {
             Err(e) if e.code() == "ai_overloaded" && attempt == 0 => {
                 attempt = 1;
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -277,6 +336,7 @@ async fn stream_tools_once(
     key: &str,
     request: &ToolRequest,
     on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
 ) -> Result<AssistantTurn> {
     let mut body = json!({
         "model": request.model,
@@ -333,7 +393,13 @@ async fn stream_tools_once(
                 let Some(data) = line.strip_prefix("data:") else {
                     continue;
                 };
-                apply_sse(data.trim(), &mut blocks, &mut stop_reason, on_delta)?;
+                apply_sse(
+                    data.trim(),
+                    &mut blocks,
+                    &mut stop_reason,
+                    on_delta,
+                    on_reasoning,
+                )?;
             }
         }
     }
@@ -348,6 +414,7 @@ fn apply_sse(
     blocks: &mut BTreeMap<usize, BlockAccum>,
     stop_reason: &mut Option<String>,
     on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
 ) -> Result<()> {
     let Ok(event) = serde_json::from_str::<ToolSse>(data) else {
         return Ok(());
@@ -373,10 +440,14 @@ fn apply_sse(
                     },
                 );
             }
+            // Both reasoning shapes report on arrival: the block's own text is
+            // empty unless the request asked for it, and a redacted one carries
+            // no readable text at all. See [`stream`].
             ToolBlockStart::Thinking {
                 thinking,
                 signature,
             } => {
+                on_reasoning();
                 blocks.insert(
                     index,
                     BlockAccum::Thinking {
@@ -386,6 +457,7 @@ fn apply_sse(
                 );
             }
             ToolBlockStart::RedactedThinking { data } => {
+                on_reasoning();
                 blocks.insert(index, BlockAccum::Redacted { data });
             }
             ToolBlockStart::Other => {}
@@ -416,10 +488,13 @@ fn apply_sse(
             // nothing to accumulate.
             Some(BlockAccum::Redacted { .. }) => {}
             None => {
-                // Delta before its start frame — recover text.
+                // Delta before its start frame — recover text, and report
+                // reasoning that would otherwise be lost with its block.
                 if let Some(t) = delta.text {
                     on_delta(&t);
                     blocks.insert(index, BlockAccum::Text(t));
+                } else if delta.thinking.is_some() {
+                    on_reasoning();
                 }
             }
         },
@@ -547,24 +622,97 @@ mod tests {
         assert_eq!(msgs, vec![json!({ "role": "user", "content": "hi" })]);
     }
 
-    /// Feed SSE payloads through the parser, returning the assembled turn plus
-    /// everything that reached `on_delta`.
-    fn run_sse(frames: &[Value]) -> (AssistantTurn, String) {
+    /// Feed SSE payloads through the tool-path parser, returning the assembled
+    /// turn, everything that reached `on_delta`, and how many times reasoning
+    /// was reported. The count is part of the result on purpose: a spurious
+    /// report has nowhere to hide if the harness only looks at the text.
+    fn run_sse(frames: &[Value]) -> (AssistantTurn, String, usize) {
         let mut blocks = BTreeMap::new();
         let mut stop_reason = None;
         let mut streamed = String::new();
+        let mut reasoning = 0;
         {
             let mut on_delta = |s: &str| streamed.push_str(s);
+            let mut on_reasoning = || reasoning += 1;
             for f in frames {
-                apply_sse(&f.to_string(), &mut blocks, &mut stop_reason, &mut on_delta).unwrap();
+                apply_sse(
+                    &f.to_string(),
+                    &mut blocks,
+                    &mut stop_reason,
+                    &mut on_delta,
+                    &mut on_reasoning,
+                )
+                .unwrap();
             }
         }
-        (assemble_turn(blocks, stop_reason), streamed)
+        (assemble_turn(blocks, stop_reason), streamed, reasoning)
+    }
+
+    /// Same, for the non-tool path that serves the recap, the composer and the
+    /// style scan. Returns the streamed answer, the reasoning count, and the
+    /// stop reason.
+    fn run_text_sse(frames: &[Value]) -> (String, usize, Option<String>) {
+        let mut stop_reason = None;
+        let mut streamed = String::new();
+        let mut reasoning = 0;
+        {
+            let mut on_delta = |s: &str| streamed.push_str(s);
+            let mut on_reasoning = || reasoning += 1;
+            for f in frames {
+                apply_text_sse(
+                    &f.to_string(),
+                    &mut stop_reason,
+                    &mut on_delta,
+                    &mut on_reasoning,
+                )
+                .unwrap();
+            }
+        }
+        (streamed, reasoning, stop_reason)
+    }
+
+    #[test]
+    fn text_path_reports_reasoning_and_streams_only_the_answer() {
+        let (streamed, reasoning, stop_reason) = run_text_sse(&[
+            json!({"type": "content_block_start", "index": 0,
+                   "content_block": {"type": "thinking", "thinking": ""}}),
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "thinking_delta", "thinking": "let me check"}}),
+            json!({"type": "content_block_start", "index": 1,
+                   "content_block": {"type": "text", "text": ""}}),
+            json!({"type": "content_block_delta", "index": 1,
+                   "delta": {"type": "text_delta", "text": "Found it."}}),
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"}}),
+        ]);
+        // The current models think by default and return no reasoning text
+        // unless the request asks for it, so the block arrives empty: its
+        // arrival is the signal, not its contents.
+        assert!(reasoning >= 1);
+        assert_eq!(streamed, "Found it.");
+        assert_eq!(stop_reason.as_deref(), Some("end_turn"));
+    }
+
+    #[test]
+    fn text_path_stays_quiet_on_everything_else() {
+        // Reading `content_block_start` must not make ordinary blocks look like
+        // reasoning, and an unknown frame must still be skipped, not fail.
+        let (streamed, reasoning, stop_reason) = run_text_sse(&[
+            json!({"type": "message_start", "message": {"id": "msg_1"}}),
+            json!({"type": "content_block_start", "index": 0,
+                   "content_block": {"type": "tool_use", "id": "t1", "name": "search"}}),
+            json!({"type": "content_block_start", "index": 1,
+                   "content_block": {"type": "text", "text": "hi"}}),
+            json!({"type": "some_future_event", "whatever": true}),
+            json!({"type": "content_block_stop", "index": 1}),
+        ]);
+        assert_eq!(reasoning, 0);
+        assert_eq!(streamed, "");
+        assert!(stop_reason.is_none());
     }
 
     #[test]
     fn thinking_is_captured_but_never_streamed() {
-        let (turn, streamed) = run_sse(&[
+        let (turn, streamed, reasoning) = run_sse(&[
             json!({"type": "content_block_start", "index": 0,
                    "content_block": {"type": "thinking", "thinking": ""}}),
             json!({"type": "content_block_delta", "index": 0,
@@ -577,9 +725,11 @@ mod tests {
                    "delta": {"type": "text_delta", "text": "Found it."}}),
             json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"}}),
         ]);
-        // The answer is only the text block — reasoning must not leak into it.
+        // The answer is only the text block — reasoning must not leak into it,
+        // but it is reported out of band.
         assert_eq!(turn.text, "Found it.");
         assert_eq!(streamed, "Found it.");
+        assert_eq!(reasoning, 1);
         match turn.thinking.as_slice() {
             [ThinkingBlock::Thinking { text, signature }] => {
                 assert_eq!(text, "let me check");
@@ -590,10 +740,44 @@ mod tests {
     }
 
     #[test]
+    fn reasoning_is_reported_on_arrival_even_with_no_text() {
+        // The current models think by default and return no reasoning text
+        // unless the request asks for it, so this is the shape that actually
+        // arrives: an empty block, then the answer. It must still report.
+        let (turn, streamed, reasoning) = run_sse(&[
+            json!({"type": "content_block_start", "index": 0,
+                   "content_block": {"type": "thinking", "thinking": ""}}),
+            json!({"type": "content_block_start", "index": 1,
+                   "content_block": {"type": "text", "text": ""}}),
+            json!({"type": "content_block_delta", "index": 1,
+                   "delta": {"type": "text_delta", "text": "Found it."}}),
+        ]);
+        assert_eq!(reasoning, 1);
+        assert_eq!(streamed, "Found it.");
+        assert_eq!(turn.text, "Found it.");
+    }
+
+    #[test]
+    fn an_answer_never_reads_as_reasoning() {
+        // A round with no thinking at all must report none, however the text
+        // block is shaped (an empty opening text block is the norm).
+        let (turn, streamed, reasoning) = run_sse(&[
+            json!({"type": "content_block_start", "index": 0,
+                   "content_block": {"type": "text", "text": ""}}),
+            json!({"type": "content_block_delta", "index": 0,
+                   "delta": {"type": "text_delta", "text": "Straight answer."}}),
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"}}),
+        ]);
+        assert_eq!(reasoning, 0);
+        assert_eq!(streamed, "Straight answer.");
+        assert_eq!(turn.text, "Straight answer.");
+    }
+
+    #[test]
     fn thinking_that_eats_the_budget_yields_no_text() {
         // The bug this guards: reasoning spends the whole max_tokens ceiling,
         // so the round ends with a stop reason and nothing to show.
-        let (turn, streamed) = run_sse(&[
+        let (turn, streamed, reasoning) = run_sse(&[
             json!({"type": "content_block_start", "index": 0,
                    "content_block": {"type": "thinking", "thinking": ""}}),
             json!({"type": "content_block_delta", "index": 0,
@@ -603,19 +787,23 @@ mod tests {
         assert!(turn.text.is_empty());
         assert!(streamed.is_empty());
         assert_eq!(turn.stop_reason.as_deref(), Some("max_tokens"));
+        // Nothing to show, but the user was told the model was working.
+        assert_eq!(reasoning, 1);
         // Unsigned, so it can't be replayed and is dropped.
         assert!(turn.thinking.is_empty());
     }
 
     #[test]
     fn redacted_thinking_survives_for_replay() {
-        let (turn, _) = run_sse(&[
+        let (turn, _, reasoning) = run_sse(&[
             json!({"type": "content_block_start", "index": 0,
                    "content_block": {"type": "redacted_thinking", "data": "encrypted"}}),
             json!({"type": "content_block_start", "index": 1,
                    "content_block": {"type": "text", "text": "ok"}}),
         ]);
         assert_eq!(turn.text, "ok");
+        // Encrypted reasoning is still reasoning: the round is not silent.
+        assert_eq!(reasoning, 1);
         match turn.thinking.as_slice() {
             [ThinkingBlock::Redacted { data }] => assert_eq!(data, "encrypted"),
             other => panic!("expected one redacted block, got {other:?}"),
@@ -624,7 +812,7 @@ mod tests {
 
     #[test]
     fn thinking_does_not_disturb_tool_calls() {
-        let (turn, _) = run_sse(&[
+        let (turn, _, reasoning) = run_sse(&[
             json!({"type": "content_block_start", "index": 0,
                    "content_block": {"type": "thinking", "thinking": "x", "signature": "s"}}),
             json!({"type": "content_block_start", "index": 1,
@@ -637,6 +825,8 @@ mod tests {
         assert_eq!(turn.tool_calls.len(), 1);
         assert_eq!(turn.tool_calls[0].input["query"], "alta");
         assert_eq!(turn.thinking.len(), 1);
+        // The tool block must not be mistaken for reasoning.
+        assert_eq!(reasoning, 1);
     }
 
     #[test]

--- a/src-tauri/src/ai/openai_compat.rs
+++ b/src-tauri/src/ai/openai_compat.rs
@@ -7,7 +7,7 @@ use super::{AssistantTurn, ChatMessage, ToolCall};
 use crate::error::{Result, SkimError};
 use futures::StreamExt;
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::BTreeMap;
 
 /// Where an OpenAI-compatible request goes.
@@ -149,17 +149,27 @@ fn drain_data(buffer: &mut String, flush: bool) -> Vec<String> {
     out
 }
 
-/// Stream a completion, invoking `on_delta` for each text fragment.
+/// Stream a completion, invoking `on_delta` for each text fragment and
+/// `on_reasoning` while the model thinks before it answers.
 /// Returns the finish reason. Honors one retry on rate-limit/upstream errors.
+///
+/// A thinking model sends its reasoning first, in frames whose `content` is
+/// empty, which from the outside looks exactly like a model still loading; a
+/// local one can reason for a minute. The reasoning text itself is dropped, it
+/// must never reach the answer body, but its arrival is worth reporting, and
+/// that is all `on_reasoning` says. It fires per frame, not once per round;
+/// the caller decides what to make of that. [`super::anthropic`] reports
+/// thinking through the same pair of callbacks.
 pub async fn stream(
     ep: &Endpoint,
     key: &str,
     request: &Request,
     mut on_delta: impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
 ) -> Result<Option<String>> {
     let mut attempt = 0;
     loop {
-        match stream_once(ep, key, request, &mut on_delta).await {
+        match stream_once(ep, key, request, &mut on_delta, on_reasoning).await {
             Err(e) if e.code() == "ai_overloaded" && attempt == 0 => {
                 attempt = 1;
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -174,6 +184,7 @@ async fn stream_once(
     key: &str,
     request: &Request,
     on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
 ) -> Result<Option<String>> {
     let resp = post_chat(ep, key, &chat_body(request))
         .send()
@@ -208,6 +219,9 @@ async fn stream_once(
                 return Err(SkimError::other("ai", error.message));
             }
             for choice in event.choices {
+                if choice.delta.thinking() {
+                    on_reasoning();
+                }
                 if let Some(text) = choice.delta.content {
                     if !text.is_empty() {
                         on_delta(&text);
@@ -238,10 +252,41 @@ struct Choice {
     finish_reason: Option<String>,
 }
 
+/// One `choices[].delta`, shared by both wire shapes: `tool_calls` is simply
+/// absent from a plain completion, and serde defaults it to `None`.
 #[derive(Deserialize, Default)]
 struct Delta {
     #[serde(default)]
     content: Option<String>,
+    #[serde(default)]
+    reasoning: Option<Value>,
+    #[serde(default)]
+    reasoning_content: Option<Value>,
+    #[serde(default)]
+    tool_calls: Option<Vec<ToolCallDelta>>,
+}
+
+impl Delta {
+    fn thinking(&self) -> bool {
+        carries_reasoning(&self.reasoning) || carries_reasoning(&self.reasoning_content)
+    }
+}
+
+/// Did the endpoint put actual reasoning under this key? Deliberately untyped:
+/// the text is never read, and gateways spell it as a string, an object, or a
+/// list of blocks. Typing it as a string would make one of those shapes fail
+/// the whole frame, taking its `content` and `tool_calls` down with it.
+///
+/// A bare `true` or a number is not reasoning: some endpoints carry a flag
+/// under this name on every frame, and reading that as "the model is thinking"
+/// would fire on the very first one, before the model produced anything.
+fn carries_reasoning(field: &Option<Value>) -> bool {
+    match field {
+        Some(Value::String(s)) => !s.is_empty(),
+        Some(Value::Array(a)) => !a.is_empty(),
+        Some(Value::Object(o)) => !o.is_empty(),
+        _ => false,
+    }
 }
 
 #[derive(Deserialize)]
@@ -252,17 +297,19 @@ struct ApiError {
 // ---- tool-calling ---------------------------------------------------------
 
 /// Stream one assistant round that may include tool calls. Text streams to
-/// `on_delta`; `tool_calls` are accumulated and returned. One retry on
-/// rate-limit/upstream errors (before any bytes stream).
+/// `on_delta` and reasoning is reported through `on_reasoning` (see [`stream`]);
+/// `tool_calls` are accumulated and returned. One retry on rate-limit/upstream
+/// errors (before any bytes stream).
 pub async fn stream_tools(
     ep: &Endpoint,
     key: &str,
     request: &ToolRequest,
     on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
 ) -> Result<AssistantTurn> {
     let mut attempt = 0;
     loop {
-        match stream_tools_once(ep, key, request, on_delta).await {
+        match stream_tools_once(ep, key, request, on_delta, on_reasoning).await {
             Err(e) if e.code() == "ai_overloaded" && attempt == 0 => {
                 attempt = 1;
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
@@ -318,6 +365,7 @@ async fn stream_tools_once(
     key: &str,
     request: &ToolRequest,
     on_delta: &mut impl FnMut(&str),
+    on_reasoning: &mut impl FnMut(),
 ) -> Result<AssistantTurn> {
     let resp = post_chat(ep, key, &tool_body(request))
         .send()
@@ -354,6 +402,9 @@ async fn stream_tools_once(
                 return Err(SkimError::other("ai", error.message));
             }
             for choice in event.choices {
+                if choice.delta.thinking() {
+                    on_reasoning();
+                }
                 if let Some(t) = choice.delta.content {
                     if !t.is_empty() {
                         on_delta(&t);
@@ -404,17 +455,9 @@ struct ToolChunk {
 #[derive(Deserialize)]
 struct ToolChoice {
     #[serde(default)]
-    delta: ToolDeltaBody,
+    delta: Delta,
     #[serde(default)]
     finish_reason: Option<String>,
-}
-
-#[derive(Deserialize, Default)]
-struct ToolDeltaBody {
-    #[serde(default)]
-    content: Option<String>,
-    #[serde(default)]
-    tool_calls: Option<Vec<ToolCallDelta>>,
 }
 
 #[derive(Deserialize)]
@@ -534,6 +577,56 @@ mod tests {
         let mut buffer = "data: {\"a\":1}".to_string();
         assert_eq!(drain_data(&mut buffer, true), vec!["{\"a\":1}"]);
         assert!(buffer.is_empty());
+    }
+
+    #[test]
+    fn reasoning_is_spotted_under_either_spelling() {
+        let delta = |json: &str| serde_json::from_str::<Delta>(json).unwrap();
+        // `reasoning` is what OpenRouter and Ollama's /v1 send; DeepSeek and
+        // vLLM spell it `reasoning_content`.
+        assert!(delta(r#"{"content":"","reasoning":"let me think"}"#).thinking());
+        assert!(delta(r#"{"content":"","reasoning_content":"let me think"}"#).thinking());
+        // Answer text is not reasoning, and an empty field is not a sign of life.
+        assert!(!delta(r#"{"content":"hello"}"#).thinking());
+        assert!(!delta(r#"{"reasoning":""}"#).thinking());
+        assert!(!delta(r#"{"reasoning":null}"#).thinking());
+    }
+
+    #[test]
+    fn only_reasoning_content_counts_as_reasoning() {
+        let delta = |json: &str| serde_json::from_str::<Delta>(json).unwrap();
+        // A gateway may carry reasoning as an object or a list of blocks. The
+        // frame must still parse: dropping it would drop its `content` too.
+        let chunk: Chunk = serde_json::from_str(
+            r#"{"choices":[{"delta":{"content":"hi","reasoning":{"text":"hmm"}}}]}"#,
+        )
+        .unwrap();
+        assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("hi"));
+        assert!(chunk.choices[0].delta.thinking());
+        assert!(delta(r#"{"reasoning_content":[{"type":"thinking"}]}"#).thinking());
+
+        // An empty container is a placeholder, and a bare flag is not content:
+        // an endpoint that sends either on every frame must not read as a model
+        // reasoning from the very first one.
+        assert!(!delta(r#"{"reasoning":{}}"#).thinking());
+        assert!(!delta(r#"{"reasoning":[]}"#).thinking());
+        assert!(!delta(r#"{"reasoning":false}"#).thinking());
+        assert!(!delta(r#"{"reasoning":true}"#).thinking());
+        assert!(!delta(r#"{"reasoning":0}"#).thinking());
+    }
+
+    #[test]
+    fn one_delta_shape_serves_both_wire_formats() {
+        // `tool_calls` is simply absent from a plain completion.
+        let plain: Chunk =
+            serde_json::from_str(r#"{"choices":[{"delta":{"content":"hi"}}]}"#).unwrap();
+        assert!(plain.choices[0].delta.tool_calls.is_none());
+
+        let tools: ToolChunk = serde_json::from_str(
+            r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c1"}]}}]}"#,
+        )
+        .unwrap();
+        assert_eq!(tools.choices[0].delta.tool_calls.as_ref().unwrap().len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -17,6 +17,11 @@ pub enum AiEvent {
     Delta {
         text: String,
     },
+    /// The model is reasoning before it answers. Nothing to render: it only
+    /// says the model is alive, so the UI can stop guessing that a silent
+    /// round means one still loading. Sent once per round, whatever the
+    /// provider reported (see [`reasoning_once`]).
+    Reasoning,
     Progress {
         current: usize,
         total: usize,
@@ -339,6 +344,7 @@ fn spawn_stream(
                 text: delta.to_string(),
             });
         };
+        let mut on_reasoning = reasoning_once(&channel);
         let result = match &ctx.endpoint {
             None => {
                 let request = anthropic::Request {
@@ -348,7 +354,7 @@ fn spawn_stream(
                     media,
                     max_tokens,
                 };
-                anthropic::stream(&ctx.key, &request, &mut on_delta).await
+                anthropic::stream(&ctx.key, &request, &mut on_delta, &mut on_reasoning).await
             }
             Some(ep) => {
                 // OpenAI-compatible endpoints have no native attachment path;
@@ -360,7 +366,8 @@ fn spawn_stream(
                     messages,
                     max_tokens,
                 };
-                openai_compat::stream(ep, &ctx.key, &request, &mut on_delta).await
+                openai_compat::stream(ep, &ctx.key, &request, &mut on_delta, &mut on_reasoning)
+                    .await
             }
         };
         match result {
@@ -378,6 +385,21 @@ fn spawn_stream(
     if let Ok(mut tasks) = state.ai_tasks.lock() {
         tasks.retain(|_, h| !h.is_finished());
         tasks.insert(request_id, task.abort_handle());
+    }
+}
+
+/// One `Reasoning` event per round, whatever the provider reports. The
+/// streaming clients call `on_reasoning` per frame, because "is this the first
+/// one" is not their business: a round can open several reasoning blocks, and
+/// the frames carry no text to count anyway. Collapsing that to a single event
+/// belongs here, once, for every provider and every command.
+fn reasoning_once(channel: &Channel<AiEvent>) -> impl FnMut() + '_ {
+    let mut reported = false;
+    move || {
+        if !reported {
+            reported = true;
+            let _ = channel.send(AiEvent::Reasoning);
+        }
     }
 }
 
@@ -713,6 +735,7 @@ pub async fn ai_ask(
                 text: d.to_string(),
             });
         };
+        let mut on_reasoning = reasoning_once(&channel);
         let on_tool_call = move |id: &str, kind: &str, arg: &str| {
             let _ = ch_call.send(AiEvent::ToolCall {
                 id: id.to_string(),
@@ -737,6 +760,7 @@ pub async fn ai_ask(
             agent::ToolSet::FETCH_ONLY,
             deps,
             &mut on_delta,
+            &mut on_reasoning,
             &on_tool_call,
             &on_tool_done,
         )
@@ -808,6 +832,7 @@ pub async fn ai_chat(
                 text: d.to_string(),
             });
         };
+        let mut on_reasoning = reasoning_once(&channel);
         let on_tool_call = move |id: &str, kind: &str, arg: &str| {
             let _ = ch_call.send(AiEvent::ToolCall {
                 id: id.to_string(),
@@ -832,6 +857,7 @@ pub async fn ai_chat(
             agent::ToolSet::MAILBOX,
             deps,
             &mut on_delta,
+            &mut on_reasoning,
             &on_tool_call,
             &on_tool_done,
         )
@@ -1049,8 +1075,9 @@ pub async fn ai_analyze_style(
                 text: delta.to_string(),
             });
         };
+        let mut on_reasoning = reasoning_once(&channel);
         let result = match &ctx.endpoint {
-            None => anthropic::stream(&ctx.key, &request, &mut on_delta).await,
+            None => anthropic::stream(&ctx.key, &request, &mut on_delta, &mut on_reasoning).await,
             Some(ep) => {
                 let request = openai_compat::Request {
                     model: ctx.model,
@@ -1058,7 +1085,8 @@ pub async fn ai_analyze_style(
                     messages: user_turn(user),
                     max_tokens: STYLE_MAX_TOKENS,
                 };
-                openai_compat::stream(ep, &ctx.key, &request, &mut on_delta).await
+                openai_compat::stream(ep, &ctx.key, &request, &mut on_delta, &mut on_reasoning)
+                    .await
             }
         };
         match result {

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -19,7 +19,7 @@ pub enum AiEvent {
     },
     /// The model is reasoning before it answers. Nothing to render: it only
     /// says the model is alive, so the UI can stop guessing that a silent
-    /// round means one still loading. Sent once per round, whatever the
+    /// round means one still loading. Sent once per request, whatever the
     /// provider reported (see [`reasoning_once`]).
     Reasoning,
     Progress {
@@ -388,11 +388,12 @@ fn spawn_stream(
     }
 }
 
-/// One `Reasoning` event per round, whatever the provider reports. The
-/// streaming clients call `on_reasoning` per frame, because "is this the first
-/// one" is not their business: a round can open several reasoning blocks, and
-/// the frames carry no text to count anyway. Collapsing that to a single event
-/// belongs here, once, for every provider and every command.
+/// One `Reasoning` event per request: the latch is built once per command, so
+/// it spans every round of an agent loop too. The streaming clients call
+/// `on_reasoning` per frame, because "is this the first one" is not their
+/// business: a round can open several reasoning blocks, and the frames carry no
+/// text to count anyway. Collapsing that to a single event belongs here, once,
+/// for every provider and every command.
 fn reasoning_once(channel: &Channel<AiEvent>) -> impl FnMut() + '_ {
     let mut reported = false;
     move || {

--- a/src/components/AiAsk.svelte
+++ b/src/components/AiAsk.svelte
@@ -4,7 +4,7 @@
   // is owned by the main window's store, so this can be mounted, unmounted and
   // mirrored into a second window without touching the conversation.
   import { aiLinks } from "../lib/ai-links";
-  import type { ChatSession } from "../lib/ai-chat";
+  import { isAlive, type ChatSession } from "../lib/ai-chat";
   import { t } from "../lib/i18n/index.svelte";
   import { mdLite } from "../lib/md";
   import { createSlowStart } from "../lib/slow-start.svelte";
@@ -42,7 +42,7 @@
     wasStreaming = now;
   });
   $effect(() => {
-    if (session.answer !== "" || session.steps.length > 0) slowStart.clear();
+    if (isAlive(session)) slowStart.clear();
   });
 
   function send(q: string) {

--- a/src/components/AiAsk.svelte
+++ b/src/components/AiAsk.svelte
@@ -41,6 +41,8 @@
     if (!now) slowStart.clear();
     wasStreaming = now;
   });
+  // Guarded in the template too: this effect runs after the DOM update, so on
+  // its own the label would flash "loading" for one frame.
   $effect(() => {
     if (isAlive(session)) slowStart.clear();
   });
@@ -118,7 +120,7 @@
             </div>
           {/if}
           {#if session.answer === ""}
-            <span class="thinking">{slowStart.slow ? t("ai.loading_model") : t("ai.thinking")}</span>
+            <span class="thinking">{slowStart.slow && !isAlive(session) ? t("ai.loading_model") : t("ai.thinking")}</span>
           {:else}
             <div class="ai-text md-body" use:aiLinks>{@html mdLite(session.answer)}</div>
           {/if}

--- a/src/components/AiChat.svelte
+++ b/src/components/AiChat.svelte
@@ -4,7 +4,7 @@
   // only — the session and the request live in the main window's store.
   import type { Citation } from "../lib/api";
   import { aiLinks } from "../lib/ai-links";
-  import type { ChatSession } from "../lib/ai-chat";
+  import { isAlive, type ChatSession } from "../lib/ai-chat";
   import { t } from "../lib/i18n/index.svelte";
   import { mdLite } from "../lib/md";
   import { createSlowStart } from "../lib/slow-start.svelte";
@@ -41,7 +41,7 @@
     wasStreaming = now;
   });
   $effect(() => {
-    if (session.answer !== "" || session.steps.length > 0) slowStart.clear();
+    if (isAlive(session)) slowStart.clear();
   });
 
   function submitFollowup(e: SubmitEvent) {

--- a/src/components/AiChat.svelte
+++ b/src/components/AiChat.svelte
@@ -40,6 +40,8 @@
     if (!now) slowStart.clear();
     wasStreaming = now;
   });
+  // Guarded in the template too: this effect runs after the DOM update, so on
+  // its own the label would flash "loading" for one frame.
   $effect(() => {
     if (isAlive(session)) slowStart.clear();
   });
@@ -135,7 +137,7 @@
       <div class="chat-answer">
         <div class="microlabel chat-label">✦ {t("ai.answer")}</div>
         {#if session.answer === ""}
-          <span class="thinking">{slowStart.slow ? t("ai.loading_model") : t("ai.thinking")}</span>
+          <span class="thinking">{slowStart.slow && !isAlive(session) ? t("ai.loading_model") : t("ai.thinking")}</span>
         {:else}
           <div class="chat-text md-body" use:aiLinks>{@html mdLite(session.answer)}</div>
         {/if}

--- a/src/components/AiRecap.svelte
+++ b/src/components/AiRecap.svelte
@@ -61,6 +61,8 @@
     // itself finishes — re-arm on every progress tick.
     if (session.progress) slowStart.arm();
   });
+  // Guarded in the template too: this effect runs after the DOM update, so on
+  // its own the label would flash "loading" for one frame.
   $effect(() => {
     if (isAlive(session)) slowStart.clear();
   });
@@ -109,7 +111,7 @@
     {#if scanning}
       <div class="progress">
         <span class="spinner"></span>
-        {#if slowStart.slow}
+        {#if slowStart.slow && !isAlive(session)}
           {t("ai.loading_model")}
         {:else if session.reasoning}
           <!-- The scan is over and the digest is being thought through: the
@@ -207,7 +209,7 @@
             <div class="chat-answer">
               <div class="microlabel chat-label">✦ {t("ai.answer")}</div>
               {#if session.answer === ""}
-                <span class="thinking">{slowStart.slow ? t("ai.loading_model") : t("ai.thinking")}</span>
+                <span class="thinking">{slowStart.slow && !isAlive(session) ? t("ai.loading_model") : t("ai.thinking")}</span>
               {:else}
                 <div class="chat-text md-body" use:aiLinks>{@html mdLite(session.answer)}</div>
               {/if}

--- a/src/components/AiRecap.svelte
+++ b/src/components/AiRecap.svelte
@@ -9,7 +9,7 @@
   // (turns 0 and 1); anything after that is a follow-up the user asked.
   import type { Citation } from "../lib/api";
   import { aiLinks } from "../lib/ai-links";
-  import type { ChatSession } from "../lib/ai-chat";
+  import { isAlive, type ChatSession } from "../lib/ai-chat";
   import { t } from "../lib/i18n/index.svelte";
   import { mdLite } from "../lib/md";
   import { createSlowStart } from "../lib/slow-start.svelte";
@@ -62,7 +62,7 @@
     if (session.progress) slowStart.arm();
   });
   $effect(() => {
-    if (session.answer !== "" || session.steps.length > 0) slowStart.clear();
+    if (isAlive(session)) slowStart.clear();
   });
 
   // Keep the panel pinned to the newest turn / streaming delta.
@@ -111,6 +111,10 @@
         <span class="spinner"></span>
         {#if slowStart.slow}
           {t("ai.loading_model")}
+        {:else if session.reasoning}
+          <!-- The scan is over and the digest is being thought through: the
+               counter would sit frozen at N/N saying "reading". -->
+          {t("ai.thinking")}
         {:else}
           {t("ai.recap_reading")}
           {#if session.progress}{session.progress.current}/{session.progress.total}{/if}

--- a/src/components/ComposeForm.svelte
+++ b/src/components/ComposeForm.svelte
@@ -278,6 +278,8 @@
         replyToMessageId: draft.replyToMessageId,
       },
       {
+        // The model started reasoning: it is working, not still loading.
+        reasoning: () => slowStart.clear(),
         delta: (text) => {
           slowStart.clear();
           streamed += text;

--- a/src/components/settings/Settings.svelte
+++ b/src/components/settings/Settings.svelte
@@ -111,6 +111,8 @@
   let styleProfile = $state("");
   let styleScanning = $state(false);
   let styleProgress = $state<{ current: number; total: number } | null>(null);
+  /** The model is thinking: the scan is done, the profile is not being written yet. */
+  let styleReasoning = $state(false);
   let styleError = $state("");
   let cancelScan: (() => void) | null = null;
 
@@ -181,11 +183,19 @@
     styleError = "";
     styleProfile = "";
     styleProgress = null;
+    styleReasoning = false;
     cancelScan = aiStream(
       "ai_analyze_style",
       {},
       {
         progress: (current, total) => (styleProgress = { current, total }),
+        // The scan is over, but nothing is being written yet: say so rather
+        // than leaving the counter frozen at N/N or claiming a profile is
+        // already being distilled.
+        reasoning: () => {
+          styleProgress = null;
+          styleReasoning = true;
+        },
         delta: (text) => {
           styleProgress = null;
           styleProfile += text;
@@ -808,6 +818,8 @@
                       <span class="spinner"></span>
                       {#if styleProgress}
                         {t("settings.style_mine_scan")} {styleProgress.current}/{styleProgress.total}
+                      {:else if styleReasoning && !styleProfile}
+                        {t("ai.thinking")}
                       {:else}
                         {t("settings.style_mine_writing")}
                       {/if}

--- a/src/lib/ai-chat.ts
+++ b/src/lib/ai-chat.ts
@@ -49,6 +49,9 @@ export interface ChatSession {
   turns: ChatTurn[];
   /** The in-flight answer, streaming in. */
   answer: string;
+  /** The model reasoned this round: it is alive and working, even though
+   *  there is nothing to show yet. Reasoning itself is never rendered. */
+  reasoning: boolean;
   steps: ChatStep[];
   status: "idle" | "streaming" | "error";
   errorText: string;
@@ -66,6 +69,10 @@ export type ChatEvent =
   | { t: "start" }
   | { t: "progress"; current: number; total: number }
   | { t: "delta"; text: string }
+  /** The model is reasoning: nothing to render, but it is not stuck. */
+  | { t: "reasoning" }
+  /** The user stopped the round: keep the conversation, drop what was in flight. */
+  | { t: "cancelled" }
   | { t: "toolCall"; id: string; kind: string; arg: string }
   | { t: "toolDone"; id: string; count: number | null }
   | { t: "answer"; content: string; citations: Citation[] }
@@ -92,6 +99,7 @@ export function newSession(
     markedCount: 0,
     turns: [],
     answer: "",
+    reasoning: false,
     steps: [],
     status: "idle",
     errorText: "",
@@ -102,6 +110,13 @@ export function newSession(
   };
 }
 
+/** Has the model shown any sign of life this round? Reasoning, an answer under
+ *  way, or a tool it reached for all mean the same thing to the UI: it is
+ *  working, so a "still loading" hint has no business being up. */
+export function isAlive(s: ChatSession): boolean {
+  return s.reasoning || s.answer !== "" || s.steps.length > 0;
+}
+
 /** Advance a session. Called on the owning side as the request streams, and on
  *  the window side as the same events arrive over IPC. */
 export function applyChatEvent(s: ChatSession, ev: ChatEvent): void {
@@ -109,6 +124,7 @@ export function applyChatEvent(s: ChatSession, ev: ChatEvent): void {
     case "user":
       s.turns = [...s.turns, { role: "user", content: ev.content, citations: [] }];
       s.answer = "";
+      s.reasoning = false;
       s.steps = [];
       s.status = "streaming";
       s.errorText = "";
@@ -117,6 +133,7 @@ export function applyChatEvent(s: ChatSession, ev: ChatEvent): void {
       break;
     case "start":
       s.answer = "";
+      s.reasoning = false;
       s.steps = [];
       s.status = "streaming";
       s.errorText = "";
@@ -130,6 +147,16 @@ export function applyChatEvent(s: ChatSession, ev: ChatEvent): void {
       s.progress = null;
       s.answer += ev.text;
       break;
+    case "reasoning":
+      s.reasoning = true;
+      break;
+    case "cancelled":
+      s.answer = "";
+      s.reasoning = false;
+      s.steps = [];
+      s.progress = null;
+      s.status = "idle";
+      break;
     case "toolCall":
       s.steps = [...s.steps, { id: ev.id, kind: ev.kind, arg: ev.arg, count: null, done: false }];
       break;
@@ -141,6 +168,7 @@ export function applyChatEvent(s: ChatSession, ev: ChatEvent): void {
     case "answer":
       s.turns = [...s.turns, { role: "assistant", content: ev.content, citations: ev.citations }];
       s.answer = "";
+      s.reasoning = false;
       s.steps = [];
       s.status = "idle";
       break;
@@ -152,6 +180,7 @@ export function applyChatEvent(s: ChatSession, ev: ChatEvent): void {
         { role: "assistant", content: ev.content, citations: ev.citations },
       ];
       s.answer = "";
+      s.reasoning = false;
       s.steps = [];
       s.progress = null;
       s.status = "idle";
@@ -168,6 +197,7 @@ export function applyChatEvent(s: ChatSession, ev: ChatEvent): void {
         s.turns = s.turns.slice(0, -1);
       }
       s.answer = "";
+      s.reasoning = false;
       s.steps = [];
       s.progress = null;
       s.status = "error";

--- a/src/lib/ai-chat.ts
+++ b/src/lib/ai-chat.ts
@@ -148,6 +148,10 @@ export function applyChatEvent(s: ChatSession, ev: ChatEvent): void {
       s.answer += ev.text;
       break;
     case "reasoning":
+      // Reasoning means the scan is over too, same as `delta`: drop the
+      // counter here rather than leaving it to a template that happens to
+      // test `reasoning` before `progress`.
+      s.progress = null;
       s.reasoning = true;
       break;
     case "cancelled":

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -171,6 +171,7 @@ export interface Citation {
 
 export type AiEvent =
   | { type: "delta"; text: string }
+  | { type: "reasoning" }
   | { type: "progress"; current: number; total: number }
   | { type: "toolCall"; id: string; kind: string; arg: string }
   | { type: "toolDone"; id: string; count: number | null }
@@ -181,6 +182,10 @@ export interface AiHandlers {
   delta: (text: string) => void;
   done: (citations: Citation[]) => void;
   error: (code: string, message: string) => void;
+  /** The model started reasoning: nothing to render, but it is working and
+   *  not still loading. Sent once per round, by every provider, and required
+   *  on purpose: a surface that shows a waiting state has to answer for it. */
+  reasoning: () => void;
   progress?: (current: number, total: number) => void;
   toolCall?: (id: string, kind: string, arg: string) => void;
   toolDone?: (id: string, count: number | null) => void;
@@ -261,6 +266,9 @@ export function aiStream(
     switch (event.type) {
       case "delta":
         on.delta(event.text);
+        break;
+      case "reasoning":
+        on.reasoning();
         break;
       case "progress":
         on.progress?.(event.current, event.total);

--- a/src/lib/stores/aiSession.svelte.ts
+++ b/src/lib/stores/aiSession.svelte.ts
@@ -196,6 +196,7 @@ function send(session: ChatSession, question: string) {
 
   const cancel = aiStream(session.kind === "ask" ? "ai_ask" : "ai_chat", args, {
     delta: (text) => apply(session, { t: "delta", text }),
+    reasoning: () => apply(session, { t: "reasoning" }),
     toolCall: (id, kind, arg) => apply(session, { t: "toolCall", id, kind, arg }),
     toolDone: (id, count) => apply(session, { t: "toolDone", id, count }),
     done: (citations) => {
@@ -228,6 +229,7 @@ function startRecap(folderId: number): ChatSession {
     {
       progress: (current, total) => apply(session, { t: "progress", current, total }),
       delta: (text) => apply(session, { t: "delta", text }),
+      reasoning: () => apply(session, { t: "reasoning" }),
       done: (citations) => {
         streams.delete(session.id);
         // No digest means nothing to seed the chat with — show why rather than
@@ -275,11 +277,10 @@ function priorCitations(session: ChatSession): Citation[] {
 function cancel(session: ChatSession) {
   streams.get(session.id)?.();
   streams.delete(session.id);
-  if (session.status === "streaming") {
-    session.status = "idle";
-    session.answer = "";
-    session.steps = [];
-  }
+  // Through `apply`, not by hand: a chat that is popped out only learns about
+  // state changes from the events this pushes over the bridge, so a direct
+  // mutation would leave that window spinning on a request that no longer runs.
+  if (session.status === "streaming") apply(session, { t: "cancelled" });
 }
 
 function drop(session: ChatSession) {


### PR DESCRIPTION
**The symptom**

Ask Skim something with a local model. The answer takes a while to come. For the whole wait, Skim shows "The model is loading…".

The model is not loading. It finished loading long ago, and it is thinking.

**Why**

Skim only watches for answer text. A model that reasons produces none while it reasons. Skim sees silence, and concludes the model is still starting up.

The recap has the same blind spot: its counter stays stuck on "reading 20/20" for the whole thinking phase.

This is not local-model-only. The current Anthropic models think by default, so the frozen counter happens on the default provider too.

**The fix**

Both streaming clients now report reasoning, through a new `on_reasoning` callback sitting next to `on_delta`.

`commands::ai` turns that into one `Reasoning` event per round. The frontend uses it to stop showing the wrong label.

**Three points worth explaining**

*On the Anthropic side it is the arrival of the reasoning block that counts, not its contents.* The API only returns the reasoning text when the request asks for it, and a redacted block never has any. Those blocks therefore arrive empty: their mere presence is the signal.

*Two callbacks rather than an empty fragment that would mean something else.* That was my first version: much smaller, no signature touched. But it forced every caller of `on_delta` to treat a legitimate empty fragment as a signal. It meant adding three guards to existing code and keeping them there indefinitely. The explicit callback removes the convention, and the guards with it.

*The scope goes beyond `openai_compat.rs`.* The fix also touches `anthropic.rs` and threads a parameter through `agent::run`. That is the price for the contract to hold on both providers. My first version only worked on one, and that was exactly the mistake.

**Verification**

- **Ollama, live** (qwen3:8b): cold start shows "The model is loading…" then switches to "Thinking…". Warm start goes straight to "Thinking…". The recap gives way to "Thinking…" once the mail has been read.
- **Anthropic, live** with a real key (claude-sonnet-5): recap, per-message chat, mailbox chat, compose, style scan. Nothing changed in answer streaming, tool calls or citations.
- **`cargo test`**: 172 tests, including new parser tests on both providers. The SSE test harness now counts reports, so a spurious one can no longer hide inside the streamed text.
