### PR TITLE
fix(mail): stop cropping wide mail, and end the frame flush with the message

### DIFF
--- a/src/components/HtmlViewer.svelte
+++ b/src/components/HtmlViewer.svelte
@@ -159,6 +159,12 @@
      default there — which would defeat a transparent body. */
   html, body { margin: 0; padding: 0; background: ${colors.bg}; }
   body {
+    /* For the height measurement below, which reads this box: keep the
+       children's margins inside. A first or last child's margin would
+       otherwise collapse out of the body, so the body's height would miss
+       what the document still counts and the frame would come up exactly
+       that margin short, which is a scrollbar on the message. */
+    display: flow-root;
     font-family: 'Hanken Grotesk', 'Segoe UI', sans-serif;
     font-size: 14px; line-height: 1.6; color: ${colors.text};
     word-wrap: break-word; overflow-wrap: break-word;
@@ -175,8 +181,44 @@
   function setupDoc(doc: Document) {
     observedDoc = doc;
     const measure = () => {
-      const h = Math.min(Math.max(doc.documentElement.scrollHeight, 40) + 8, 20000);
-      // Guard against feedback loops with percentage-height emails.
+      // Fonts and images keep their callbacks alive across a message switch,
+      // so one can fire for a document that has already been replaced. Its
+      // detached box would read zero and collapse the frame around the mail
+      // now on screen. Ask the frame what it is showing, not `observedDoc`,
+      // which only catches up once the next document has been picked up and
+      // so still names the old one during exactly this window.
+      if (doc !== iframe?.contentDocument) return;
+      // A horizontal scrollbar (a mail laid out wider than a narrow window)
+      // eats into the frame's height. Left uncounted, the frame comes up short
+      // and grows a vertical scrollbar of its own, right beside the pane's.
+      const bar = Math.max(
+        0,
+        (doc.defaultView?.innerHeight ?? 0) - doc.documentElement.clientHeight,
+      );
+      // The body's own height, never documentElement.scrollHeight: that one
+      // returns the larger of the content and the viewport, so it reads back
+      // the height just set on the frame and grows the message a little more
+      // every time the mail reflows. The body tracks the mail alone, and the
+      // flow-root above makes it exact, so the frame ends flush with the
+      // message rather than trailing a strip of canvas under it, which is
+      // also what gives the message back the bottom of its rounded corners.
+      // Both readings are needed: scrollHeight is whole while layout is
+      // fractional, so it can land a pixel short and hand the mail a scrollbar
+      // for nothing, while it alone covers a child reaching past the body.
+      const content = Math.max(
+        doc.body.scrollHeight,
+        Math.ceil(doc.body.getBoundingClientRect().height),
+      );
+      // One pixel back for scrollHeight's own rounding. It is a whole number,
+      // so content reaching a fraction of a pixel past the body (an absolutely
+      // positioned tracker, a negative margin) rounds away and the mail gets a
+      // scrollbar over less than a pixel. The rounded-up box height cannot
+      // cover it, since that box is what the content is reaching past.
+      const h = Math.min(Math.max(content, 40) + bar + 1, 20000);
+      // Guard against feedback loops with percentage-height emails. The pixel
+      // added above is what keeps this tolerance safe: at rest the frame is a
+      // pixel taller than the mail, so refusing a one-pixel gain lands it
+      // exactly flush rather than one short, which would be a scrollbar.
       if (Math.abs(h - height) > 1) height = h;
     };
     measure();

--- a/src/components/ReadingPane.svelte
+++ b/src/components/ReadingPane.svelte
@@ -814,12 +814,14 @@
     margin-left: 6px;
   }
 
+  /* Edge to edge: the message gets the whole pane, and the scrollbar sits at
+     the right of the window rather than in the middle of it. The old 840px
+     column cropped any mail laid out wider than that, with nothing to scroll
+     it back into view, while leaving the rest of a wide window unused. */
   .scroll {
     flex: 1;
     overflow-y: auto;
     padding: 8px 36px 28px;
-    max-width: 840px;
-    width: 100%;
   }
 
   .subject {


### PR DESCRIPTION
Two defects, both visible on ordinary marketing mail.

**Wide mail was cropped, with no way to see the rest.** `.scroll` capped the pane at 840px, which leaves 768px inside its padding. SignalRGB lays out at 840px, so 72px of it were unreachable: nothing scrolled them back into view.
The message also sat in a column glued to the left edge, with the pane's scrollbar running down the middle of the window.

**Every reflow added 8px of blank canvas under the message.** The height measurement read `documentElement.scrollHeight`, which returns the larger of the content and the viewport, so it read back the height it had just written to the frame. The same mail measured 788, 812, 836, then 860 across successive window resizes, each step a wider blank band.

| Before | After |
|---|---|
| <img width="1921" height="1078" alt="skim_ZcCp31pUZd" src="https://github.com/user-attachments/assets/35363178-836b-461f-8c0e-2b9cd5d39943" /> | <img width="1921" height="1078" alt="skim_tqMfpBPeO0" src="https://github.com/user-attachments/assets/a7ca4298-8cbb-486d-8cf9-69fd81d31ab6" /> |
| <img width="1921" height="1078" alt="skim_m4O6PMOZJf" src="https://github.com/user-attachments/assets/4117655a-b726-49c4-9520-52de88d3c66d" /> |<img width="1921" height="1078" alt="skim_t6UKFdgFTo" src="https://github.com/user-attachments/assets/cd5912f4-c102-43cc-9f02-6d22a588f24a" />|

Dropping the cap gives the message the pane, and a mail wider than the window now scrolls horizontally inside its own frame. Measuring the body instead of the document makes the height exact, which also hands the message back the
bottom of its rounded corners. The two commits carry the reasoning.

No breakpoints are involved: the message simply gets the width that is there.

### Known limitation, not a regression

A mail whose outermost element is an unsized background table still renders at its own width, leaving part of the pane empty. The pair below shows this PR is not the cause: the message renders identically before and after, only the pale
card behind it is gone.

| Before | After |
|---|---|
| <img width="1921" height="1078" alt="skim_L7OuBQQdc0" src="https://github.com/user-attachments/assets/f8ffd981-dc20-4aa6-b898-e532b375b309" /> | <img width="1921" height="1078" alt="skim_J3HqS67BSn" src="https://github.com/user-attachments/assets/d44e7da0-f67b-489b-9687-55f1f32d0c8d" /> |

The reason is that the sanitizer drops the mail's `<style>` block, which is where senders declare that width. Humble Bundle sizes its wrapper in one line we discard:

```css
#backgroundTable { margin:0; padding:0; width:100% !important; }
```

Of 120 real messages I tested, keeping those blocks would change 7 (2 wider, 5 narrower because they declare a `max-width` we ignore); the other 113 are identical, and nothing is unreachable in any of them. Doing it safely means
tokenizing untrusted CSS rather than scanning strings, which would mean adding a CSS parser (`cssparser`, `lightningcss`) as a dependency.

That trade is yours to make, not mine. Say the word and I will open it as a separate PR; leave it and this stays a known limitation.

### Checks

`npm run check`, `npm run build`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings` and `cargo test` all pass.

Checked against 120 real messages from my own mailbox, each through two narrow/wide resize cycles: no inner scrollbar on any of them, no height drift, nothing reaching the height cap.
