### PR TITLE
fix(ci): green up clippy on Rust 1.98

### DIFF
--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -2694,8 +2694,11 @@ fn decode_imap_utf7(s: &str) -> String {
         match engine.decode(&standard) {
             Ok(bytes) if bytes.len() % 2 == 0 => {
                 let units: Vec<u16> = bytes
-                    .chunks_exact(2)
-                    .map(|b| u16::from_be_bytes([b[0], b[1]]))
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .copied()
+                    .map(u16::from_be_bytes)
                     .collect();
                 match String::from_utf16(&units) {
                     Ok(decoded) => out.push_str(&decoded),


### PR DESCRIPTION
CI has been red on `main` since 24 August, and PR #36 inherits the failure although it only touches `ai/openai_compat.rs`.

```
error: using `chunks_exact` with a constant chunk size
    --> src\mail\sync.rs:2697:22
     |
2697 |                     .chunks_exact(2)
     |                      ^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<2>().0.iter()`
     = note: `-D clippy::chunks-exact-to-as-chunks` implied by `-D warnings`
```

Nothing in the code changed. **Rust 1.98 (released 2026-08-20) added `clippy::chunks_exact_to_as_chunks` to the default groups**, CI installs a floating stable via `dtolnay/rust-toolchain@stable`, and the Clippy step runs with `-D warnings` — so a new lint becomes a build error on the next run. The log shows the toolchain moving under us:

```
stable-x86_64-pc-windows-msvc updated - rustc 1.98.0 (88d9e12ae 2026-08-18) (from rustc 1.97.1)
```

Last green run on `main` was 19 August; the three runs after it are all red on this same line.

### The change

The call sits in `decode_imap_utf7`, the modified UTF-7 decoder for IMAP mailbox names. That arm already guards on `bytes.len() % 2 == 0`, so `chunks_exact` never had a remainder to drop and `as_chunks::<2>().0` covers exactly the same bytes. The pairs arrive as `[u8; 2]`, which `u16::from_be_bytes` takes directly — the index-by-index rebuild goes away with the lint. Byte-for-byte the same output; the three `utf7_tests`, including the round-trip, still pass untouched.

`cargo test` (258 passed), `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

### Worth deciding separately

This will happen again — with a floating stable and `-D warnings`, any Rust release can turn CI red without a commit. Two ways out: pin the toolchain in `rust-toolchain.toml` and bump it deliberately, or keep the floating stable and drop `-D warnings` for an explicit deny list. Pinning is the more predictable of the two, but it's a policy call rather than part of this fix, so I left it alone.

Note for #36: its description reports a pre-existing clippy failure at `mail/suspicion.rs:506,508` (`nonminimal_bool`) seen with clippy 1.93. That lint no longer fires on 1.98 or on 1.97 — the `chunks_exact` error above is the only one CI reports. That note can be dropped once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
