### PR TITLE
fix(ui): draw nested folders as a tree instead of full paths

### DIFF
--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -25,6 +25,9 @@ pub struct Folder {
     pub display_name: String,
     pub unread_count: i64,
     pub sort_order: i64,
+    /// The server's hierarchy separator, so the UI can read a nested folder's
+    /// path out of `display_name`. `None` until the first LIST has run.
+    pub delimiter: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src-tauri/src/db/queries.rs
+++ b/src-tauri/src/db/queries.rs
@@ -210,8 +210,10 @@ pub fn inbox_unread_by_account(conn: &Connection) -> rusqlite::Result<Vec<(Strin
 
 pub fn list_folders(conn: &Connection, account_id: &str) -> rusqlite::Result<Vec<Folder>> {
     let mut stmt = conn.prepare_cached(
-        "SELECT id, account_id, imap_name, role, display_name, unread_count, sort_order
-         FROM folders WHERE account_id = ?1 ORDER BY sort_order, display_name",
+        "SELECT f.id, f.account_id, f.imap_name, f.role, f.display_name,
+                f.unread_count, f.sort_order, a.folder_delimiter
+         FROM folders f LEFT JOIN accounts a ON a.id = f.account_id
+         WHERE f.account_id = ?1 ORDER BY f.sort_order, f.display_name",
     )?;
     let rows = stmt
         .query_map(params![account_id], |r| {
@@ -223,6 +225,7 @@ pub fn list_folders(conn: &Connection, account_id: &str) -> rusqlite::Result<Vec
                 display_name: r.get(4)?,
                 unread_count: r.get(5)?,
                 sort_order: r.get(6)?,
+                delimiter: r.get(7)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -361,10 +364,11 @@ pub fn virtual_folder_id(role: Option<&str>, display_name: &str) -> i64 {
 /// `account_id = "*"`.
 pub fn list_unified_folders(conn: &Connection) -> rusqlite::Result<Vec<Folder>> {
     let mut stmt = conn.prepare_cached(
-        "SELECT role, MIN(display_name), COALESCE(SUM(unread_count), 0), MIN(sort_order)
-         FROM folders
-         GROUP BY COALESCE('r:' || role, 'l:' || lower(display_name))
-         ORDER BY MIN(sort_order), MIN(display_name)",
+        "SELECT f.role, MIN(f.display_name), COALESCE(SUM(f.unread_count), 0),
+                MIN(f.sort_order), MIN(a.folder_delimiter)
+         FROM folders f LEFT JOIN accounts a ON a.id = f.account_id
+         GROUP BY COALESCE('r:' || f.role, 'l:' || lower(f.display_name))
+         ORDER BY MIN(f.sort_order), MIN(f.display_name)",
     )?;
     let rows = stmt
         .query_map([], |r| {
@@ -378,6 +382,7 @@ pub fn list_unified_folders(conn: &Connection) -> rusqlite::Result<Vec<Folder>> 
                 display_name,
                 unread_count: r.get(2)?,
                 sort_order: r.get(3)?,
+                delimiter: r.get(4)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;

--- a/src/components/Sidebar.svelte
+++ b/src/components/Sidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { api } from "../lib/api";
-  import { folderIcon, folderLabel, ownFoldersHeading } from "../lib/folders";
+  import { folderIcon, folderLabel, folderTree, ownFoldersHeading } from "../lib/folders";
   import { t } from "../lib/i18n/index.svelte";
   import { ai } from "../lib/stores/ai.svelte";
   import { mail } from "../lib/stores/mail.svelte";
@@ -22,7 +22,9 @@
   const mainFolders = $derived(
     mail.folders.filter((f) => f.role !== null && f.role !== "all" && f.role !== "starred"),
   );
-  const labels = $derived(mail.folders.filter((f) => f.role === null));
+  // The user's own folders, as a tree: a nested folder prints only what its
+  // parent row does not already say, and leans on an indent for the rest.
+  const labels = $derived(folderTree(mail.folders.filter((f) => f.role === null)));
   // In the unified view every connected mailbox is in scope.
   const ownHeading = $derived(
     ownFoldersHeading(
@@ -71,16 +73,18 @@
     {#if labels.length > 0}
       <div class="section">
         <div class="microlabel heading">{ownHeading}</div>
-        {#each labels as folder (folder.id)}
+        {#each labels as { folder, depth, label } (folder.id)}
+          {@const path = folderLabel(folder)}
           <button
             class="item"
             class:selected={mail.selectedFolderId === folder.id}
             onclick={() => mail.selectFolder(folder.id)}
-            title={collapsed ? folder.displayName : undefined}
+            style="--depth: {Math.min(depth, 3)}"
+            title={collapsed || path !== label ? path : undefined}
           >
             <span class="dot"></span>
-            <span class="initial" aria-hidden="true">{folder.displayName.charAt(0).toUpperCase()}</span>
-            <span class="name">{folder.displayName}</span>
+            <span class="initial" aria-hidden="true">{(Array.from(label)[0] ?? "").toUpperCase()}</span>
+            <span class="name">{label}</span>
             {#if folder.unreadCount > 0}
               <span class="count">{folder.unreadCount}</span>
             {/if}
@@ -282,6 +286,10 @@
     align-items: center;
     gap: 10px;
     padding: 7px 12px;
+    /* Nesting is drawn, not spelled out: a child folder is indented under its
+       parent instead of repeating the whole path. Capped in the markup — past
+       three levels the indent costs more room than the shorter name saves. */
+    padding-left: calc(12px + var(--depth, 0) * 12px);
     border-radius: var(--radius-s);
     color: var(--text-dim);
     font-size: 13.5px;

--- a/src/lib/folders.ts
+++ b/src/lib/folders.ts
@@ -26,11 +26,71 @@ export const roleIcon: Record<string, string> = {
   junk: "M8 2a6 6 0 1 0 0 12A6 6 0 0 0 8 2zM3.5 3.5l9 9",
 };
 
+/** A folder's path, split into its own segments. Servers nest with their own
+ *  separator ("/" on Gmail, "." on Dovecot), and many of them root every
+ *  mailbox under INBOX — that leading segment is the row already drawn at the
+ *  top of the sidebar, not a folder of the user's, so it goes. */
+export function folderSegments(folder: Pick<Folder, "displayName" | "delimiter">): string[] {
+  const delimiter = folder.delimiter || "/";
+  const segments = folder.displayName.split(delimiter);
+  return segments.length > 1 && segments[0].toUpperCase() === "INBOX"
+    ? segments.slice(1)
+    : segments;
+}
+
 /** What to call a folder: the translated role name, or the server's own name
- *  for a user label (which keeps its full path, e.g. "Work/Clients/Acme"). */
-export function folderLabel(folder: Pick<Folder, "role" | "displayName">): string {
+ *  for a user label — its full path minus the INBOX container, always spelled
+ *  with "/" (which is what the user types when creating one). */
+export function folderLabel(folder: Pick<Folder, "role" | "displayName" | "delimiter">): string {
   const key = folder.role ? roleKey[folder.role] : undefined;
-  return key ? t(key) : folder.displayName;
+  return key ? t(key) : folderSegments(folder).join("/");
+}
+
+/** One row of the sidebar's folder list: the folder, how deep to indent it, and
+ *  the part of its path worth printing. */
+export interface FolderNode {
+  folder: Folder;
+  depth: number;
+  label: string;
+}
+
+/** Order user folders as a tree: children right below their parent, indented,
+ *  labelled with only the segments the row above doesn't already show. A folder
+ *  whose parent isn't in the list (an unselectable container, say) keeps its
+ *  whole path and sits at the root — the row never hides what nothing else
+ *  spells out. */
+export function folderTree(folders: Folder[]): FolderNode[] {
+  const paths = folders.map((folder) => folderSegments(folder));
+  const order = folders.map((_, i) => i);
+  order.sort((a, b) => {
+    const x = paths[a];
+    const y = paths[b];
+    for (let i = 0; i < Math.min(x.length, y.length); i++) {
+      const cmp = x[i].localeCompare(y[i]);
+      if (cmp !== 0) return cmp;
+    }
+    return x.length - y.length;
+  });
+
+  // Parents always come first in that order, so their depth is known by the
+  // time a child looks it up.
+  const depthByPath = new Map<string, number>();
+  const key = (segments: string[]) => segments.join("\u0000").toLowerCase();
+  return order.map((i) => {
+    const segments = paths[i];
+    let depth = 0;
+    let cut = 0;
+    for (let n = segments.length - 1; n > 0; n--) {
+      const parent = depthByPath.get(key(segments.slice(0, n)));
+      if (parent !== undefined) {
+        depth = parent + 1;
+        cut = n;
+        break;
+      }
+    }
+    depthByPath.set(key(segments), depth);
+    return { folder: folders[i], depth, label: segments.slice(cut).join("/") };
+  });
 }
 
 /** Icon path for a folder, falling back to the inbox glyph. */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,6 +32,9 @@ export interface Folder {
   displayName: string;
   unreadCount: number;
   sortOrder: number;
+  /** The server's hierarchy separator — how `displayName` splits into a path.
+   *  Absent (mocks) or null (before the first sync) means "/". */
+  delimiter?: string | null;
 }
 
 export interface ThreadRow {


### PR DESCRIPTION
Fixes #38.

## The problem

On a server that roots every mailbox under `INBOX` — the default on Dovecot/cPanel — the sidebar printed the full path, so a 224px rail showed `INBOX.Top level fol…` and nothing else. Two folders in, every row looks identical and the list stops being navigable.

Nothing was shortening the name: `discover_folders` strips the `[Gmail]/` container and leaves the rest of the path in `display_name`, `folderLabel` passed it straight through, and the only thing between a long name and the reader was `text-overflow: ellipsis` — without even a `title`, so hovering told you nothing either.

## The change

Purely presentational.

- Folder rows order as a tree: a child sits directly below its parent, indented one step, labelled with only the segments the row above doesn't already spell out.
- The leading `INBOX` segment goes — it's the Inbox row at the top of the sidebar, not a folder of the user's.
- The full path is the tooltip, and `folderLabel` (list header, command palette, move picker) drops the `INBOX` container and normalises the separator to `/` — which is what the user types when creating a folder anyway.
- A folder whose parent is missing from the list (an unselectable container, say) keeps its whole path and stays at the root, so a row never hides something no other row shows.

`display_name` in the database is untouched on purpose: `rename_folder` rebuilds the wire name out of what the user sees (`wire_folder_name`), so stripping the prefix at rest would quietly move the folder out of `INBOX` on the first rename. Paths are split in the UI instead, which needs the server's hierarchy separator — already known as `accounts.folder_delimiter`, now carried on the folder rows. Guessing it frontend-side isn't an option: Dovecot nests with `.`, and an ordinary folder named `example.com` would split in two.

The sidebar width stays fixed. The issue also floated a resizable sidebar; readable labels solve the problem it was a workaround for, and a drag handle plus a stored width is a new surface and a new setting.

## Verification

`npm run check` clean; `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test` (260 passed) green.

Checked in the demo harness with INBOX-rooted fixtures: `Work` at the root, `Clients`/`Invoices` one step in, `2026` two, tooltips carrying the full path, an orphaned `Archive2024/Q1` printed whole, and the flat fixtures rendering exactly as before. Also verified the rename dialog still prefills the raw server path, so renaming still round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
